### PR TITLE
update-build-environment

### DIFF
--- a/script/build
+++ b/script/build
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
-cd "$(dirname "$0")"
+cd "$(dirname "$0")/.."
 export JAVA_HOME=/opt/android-studio/jbr
+export ANDROID_HOME=/opt/android-sdk
 ./gradlew clean assembleDebug


### PR DESCRIPTION
Updated the build script to navigate to the parent directory and export the ANDROID_HOME environment variable for proper Android SDK configuration.

This change modifies the script's working directory to the project root instead of the script's location, ensuring Gradle commands run from the correct context for the Android project. Additionally, exporting ANDROID_HOME points to the official Android SDK installation, which is required by the Android build tools and emulators to function correctly. This improves build reliability in development and CI environments by aligning with standard Android setup practices, reducing potential path-related failures and streamlining the assembly of debug APKs.