### PR TITLE
Update ANDROID_HOME to use user-specific SDK path

### DIFF
--- a/script/build
+++ b/script/build
@@ -2,5 +2,5 @@
 set -e
 cd "$(dirname "$0")/.."
 export JAVA_HOME=/opt/android-studio/jbr
-export ANDROID_HOME=/opt/android-sdk
+export ANDROID_HOME=$HOME/Android/Sdk
 ./gradlew clean assembleDebug


### PR DESCRIPTION
## Summary
- Changes ANDROID_HOME from hardcoded `/opt/android-sdk` to `$HOME/Android/Sdk` to support user-specific Android SDK installations
- Allows the build script to work across different development environments