### PR TITLE
Add environment variable support via .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Android SDK location
+ANDROID_HOME=$HOME/Android/Sdk
+
+# Java JDK location
+JAVA_HOME=/opt/android-studio/jbr

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@
 /captures
 .externalNativeBuild
 .cxx
+.env
 local.properties

--- a/script/build
+++ b/script/build
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 cd "$(dirname "$0")/.."
-export JAVA_HOME=/opt/android-studio/jbr
-export ANDROID_HOME=$HOME/Android/Sdk
+
+if [ -f .env ]; then
+    source .env
+fi
+
+export JAVA_HOME
+export ANDROID_HOME
 ./gradlew clean assembleDebug

--- a/script/run
+++ b/script/run
@@ -1,10 +1,14 @@
 #!/bin/bash
 set -e
 
-cd /home/trousev/src/MealControl
+cd "$(dirname "$0")/.."
 
-echo "Building..."
-export JAVA_HOME=/opt/android-studio/jbr
+if [ -f .env ]; then
+    source .env
+fi
+
+export JAVA_HOME
+export ANDROID_HOME
 ./gradlew clean assembleDebug
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
## Summary
- Adds `.env` file support to build and run scripts for configurable JAVA_HOME and ANDROID_HOME paths
- Adds `.env` to `.gitignore` to avoid committing sensitive paths
- Creates `.env.example` as a template for users to copy and configure

## Changes
- `script/build` and `script/run` now source `.env` if present, allowing users to set custom paths without modifying scripts
- This is useful for different development environments or CI/CD setups