### PR TITLE
add-android-test-script

### DIFF
--- a/script/test
+++ b/script/test
@@ -1,0 +1,49 @@
+#!/bin/bash
+cd "$(dirname "$0")/.."
+
+if [ -f .env ]; then
+    source .env
+fi
+
+export JAVA_HOME
+export ANDROID_HOME
+
+if [ -n "$1" ]; then
+    ./gradlew test --tests "$1"
+else
+    ./gradlew test
+fi
+test_result=$?
+
+echo ""
+echo "Test Results:"
+echo "============"
+
+total=0
+passed=0
+failed=0
+skipped=0
+
+for xml in app/build/test-results/testDebugUnitTest/*.xml; do
+    if [ -f "$xml" ]; then
+        tests=$(grep -oP '(?<=tests=")[^"]+' "$xml" | head -1)
+        failures=$(grep -oP '(?<=failures=")[^"]+' "$xml" | head -1)
+        skipped=$(grep -oP '(?<=skipped=")[^"]+' "$xml" | head -1)
+        
+        [ -z "$tests" ] && tests=0
+        [ -z "$failures" ] && failures=0
+        [ -z "$skipped" ] && skipped=0
+        
+        total=$((total + tests))
+        passed=$((passed + tests - failures - skipped))
+        failed=$((failed + failures))
+        skipped=$((skipped + skipped))
+    fi
+done
+
+echo "Tests:  $total"
+echo "Passed: $passed"
+echo "Failed: $failed"
+echo "Skipped: $skipped"
+
+exit $test_result


### PR DESCRIPTION
Added a new test script to automate unit test execution and result summarization.

This change introduces a bash script at `script/test` that runs Gradle unit tests for the Android project, optionally filtered by a specific test name if provided. It sources environment variables from a `.env` file if present, sets up JAVA_HOME and ANDROID_HOME, and executes `./gradlew test`. Following the test run, the script parses XML results from `app/build/test-results/testDebugUnitTest/` to calculate and display a summary of total tests, passed, failed, and skipped counts. The script exits with the same status as the Gradle command.

The purpose is to streamline the testing process for developers, providing an easy command-line interface to run tests and quickly assess outcomes without manually checking multiple files. This enhances productivity in the development workflow, ensures consistent environment setup, and offers better visibility into test suite health, ultimately supporting higher code quality and faster iteration cycles.