### PR TITLE
Add IME padding to Settings screen

### DIFF
--- a/app/src/main/java/pro/trousev/mealcontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/settings/SettingsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
@@ -51,7 +52,8 @@ fun SettingsScreen(
         modifier = modifier
             .fillMaxSize()
             .padding(16.dp)
-            .verticalScroll(rememberScrollState()),
+            .verticalScroll(rememberScrollState())
+            .imePadding(),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         Text(


### PR DESCRIPTION
## Summary
- Add IME padding to the Settings screen to prevent keyboard from overlapping with content when using input fields