### PR TITLE
Update FAB styling with CircleShape and primary color

### DIFF
--- a/app/src/main/java/pro/trousev/mealcontrol/ui/chat/ConversationsListScreen.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/chat/ConversationsListScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
@@ -49,7 +50,9 @@ fun ConversationsListScreen(
             FloatingActionButton(
                 onClick = {
                     viewModel.createConversation()
-                }
+                },
+                shape = CircleShape,
+                containerColor = MaterialTheme.colorScheme.primary
             ) {
                 Icon(
                     imageVector = Icons.Default.Add,


### PR DESCRIPTION
## Summary
- Update FloatingActionButton in ConversationsListScreen to use CircleShape
- Set containerColor to MaterialTheme.colorScheme.primary for better visual appearance

This improves the chat screen's FAB to match Material Design guidelines with a circular shape.