### PR TITLE
optimize-list-performance

### DIFF
--- a/app/src/main/java/pro/trousev/mealcontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/chat/ChatScreen.kt
@@ -68,7 +68,7 @@ fun ChatScreen(
 
     LaunchedEffect(conversation?.messages?.size) {
         if (conversation?.messages?.isNotEmpty() == true) {
-            listState.animateScrollToItem(conversation!!.messages.size - 1)
+            listState.animateScrollToItem(conversation?.messages?.size?.minus(1) ?: 0)
         }
     }
 
@@ -104,7 +104,7 @@ fun ChatScreen(
                 contentPadding = PaddingValues(16.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                items(messages) { message ->
+                items(messages, key = { it.id }) { message ->
                     MessageBubble(message = message)
                 }
             }
@@ -161,7 +161,7 @@ private fun MessageBubble(
     modifier: Modifier = Modifier
 ) {
     val isFromUser = message.isFromUser
-    val dateFormat = SimpleDateFormat("HH:mm", Locale.US)
+    val dateFormat = remember { SimpleDateFormat("HH:mm", Locale.US) }
 
     Column(
         modifier = modifier.fillMaxWidth(),

--- a/app/src/main/java/pro/trousev/mealcontrol/ui/chat/ConversationsListScreen.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/chat/ConversationsListScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -93,7 +94,7 @@ fun ConversationsListScreen(
             ) {
                 item { Spacer(modifier = Modifier.height(8.dp)) }
                 
-                items(conversations) { conversationWithLastMessage ->
+                items(conversations, key = { it.conversation.id }) { conversationWithLastMessage ->
                     ConversationItem(
                         conversationWithLastMessage = conversationWithLastMessage,
                         onClick = { onConversationClick(conversationWithLastMessage.conversation.id) },
@@ -117,7 +118,7 @@ private fun ConversationItem(
 ) {
     val conversation = conversationWithLastMessage.conversation
     val lastMessage = conversationWithLastMessage.lastMessage
-    val dateFormat = SimpleDateFormat("MMM dd", Locale.US)
+    val dateFormat = remember { SimpleDateFormat("MMM dd", Locale.US) }
 
     val dismissState = rememberSwipeToDismissBoxState(
         positionalThreshold = { totalDistance -> totalDistance * 0.75f },

--- a/app/src/main/java/pro/trousev/mealcontrol/ui/meals/MealsScreen.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/meals/MealsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -41,7 +42,6 @@ import pro.trousev.mealcontrol.viewmodel.MealViewModel
 import pro.trousev.mealcontrol.viewmodel.SettingsViewModel
 import java.io.File
 import java.text.SimpleDateFormat
-import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 
@@ -54,16 +54,8 @@ fun MealsScreen(
     modifier: Modifier = Modifier
 ) {
     val meals by mealViewModel.meals.collectAsState()
+    val todayMeals by mealViewModel.todayMeals.collectAsState()
     val settingsFormState by settingsViewModel.formState.collectAsState()
-
-    val todayMeals = meals.filter { meal ->
-        val mealDate = Calendar.getInstance().apply {
-            timeInMillis = meal.meal.timestamp
-        }
-        val today = Calendar.getInstance()
-        mealDate.get(Calendar.YEAR) == today.get(Calendar.YEAR) &&
-                mealDate.get(Calendar.DAY_OF_YEAR) == today.get(Calendar.DAY_OF_YEAR)
-    }
 
     val consumedCalories = todayMeals.flatMap { it.components }.sumOf { it.calories }
     val consumedProtein = todayMeals.flatMap { it.components }.sumOf { it.proteinGrams }
@@ -131,7 +123,7 @@ fun MealsScreen(
                     }
                 }
             } else {
-                items(meals) { mealWithComponents ->
+                items(meals, key = { it.meal.id }) { mealWithComponents ->
                     MealCard(
                         mealWithComponents = mealWithComponents,
                         onClick = { onMealClick(mealWithComponents) }
@@ -214,7 +206,7 @@ private fun MealCard(
     val totalProtein = components.sumOf { it.proteinGrams }
     val totalFat = components.sumOf { it.fatGrams }
     val totalCarbs = components.sumOf { it.carbGrams }
-    val dateFormat = SimpleDateFormat("MMM dd, yyyy HH:mm", Locale.US)
+    val dateFormat = remember { SimpleDateFormat("MMM dd, yyyy HH:mm", Locale.US) }
 
     Card(
         modifier = modifier


### PR DESCRIPTION
Optimized UI performance and code architecture in chat and meals screens by adding stable keys to lazy lists, wrapping date formatters with remember for efficient recomposition, and moving today's meals filtering logic from UI to ViewModel for better separation of concerns.

This change enhances app responsiveness by minimizing unnecessary recompositions in lazy lists, particularly when items are inserted or removed, leading to smoother scrolling and reduced jank in chat and conversation lists. The date formatter optimization avoids repeated object creation during UI rebuilds, improving memory efficiency. Relocating the meal filtering to the ViewModel promotes cleaner MVVM architecture, reducing UI complexity and making the code more testable and maintainable. Additionally, null-safe adjustments in chat scrolling ensure robustness against potential data inconsistencies, contributing to overall app stability and user experience without altering core business logic.