### PR TITLE
Add Compose Navigation with hierarchical back stack

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,6 +96,7 @@ dependencies {
     implementation("io.ktor:ktor-client-logging")
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.exifinterface)
+    implementation(libs.androidx.navigation.compose)
     testImplementation(libs.junit)
     testImplementation(libs.androidx.room.runtime)
     testImplementation(libs.androidx.room.ktx)

--- a/app/src/main/java/pro/trousev/mealcontrol/AppContent.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/AppContent.kt
@@ -1,26 +1,37 @@
 package pro.trousev.mealcontrol
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Email
-import androidx.compose.material.icons.filled.List
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import kotlinx.coroutines.launch
 import pro.trousev.mealcontrol.data.local.entity.MealWithComponents
 import pro.trousev.mealcontrol.ui.chat.ChatScreen
 import pro.trousev.mealcontrol.ui.chat.ConversationsListScreen
@@ -28,22 +39,41 @@ import pro.trousev.mealcontrol.ui.meals.MealsScreen
 import pro.trousev.mealcontrol.ui.scanmeal.MealEditScreen
 import pro.trousev.mealcontrol.ui.scanmeal.ScanMealScreen
 import pro.trousev.mealcontrol.ui.settings.SettingsScreen
-import pro.trousev.mealcontrol.ui.theme.MealControlTheme
 import pro.trousev.mealcontrol.viewmodel.ChatViewModel
 import pro.trousev.mealcontrol.viewmodel.MealViewModel
 import pro.trousev.mealcontrol.viewmodel.SettingsViewModel
 
 @Composable
 fun AppContent() {
-    var currentTab by rememberSaveable { mutableStateOf(AppTab.MEALS) }
-    var capturedPhotoUri by rememberSaveable { mutableStateOf<String?>(null) }
-    var showCamera by rememberSaveable { mutableStateOf(false) }
-    var editingMeal by rememberSaveable { mutableStateOf<MealWithComponents?>(null) }
-    var selectedConversationId by rememberSaveable { mutableLongStateOf(-1L) }
-
+    val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+    
+    val context = LocalContext.current
     val mealViewModel: MealViewModel = viewModel()
     val chatViewModel: ChatViewModel = viewModel()
     val settingsViewModel: SettingsViewModel = viewModel()
+
+    val selectedTab = when {
+        currentRoute == Screen.Meals.route -> AppTab.MEALS
+        currentRoute == Screen.ConversationsList.route || 
+        currentRoute?.startsWith("chat/") == true -> AppTab.CHAT
+        currentRoute == Screen.Settings.route -> AppTab.SETTINGS
+        currentRoute == Screen.ScanMeal.route -> AppTab.MEALS
+        currentRoute?.startsWith("meal_edit/") == true -> AppTab.MEALS
+        else -> AppTab.MEALS
+    }
+
+    BackHandler(enabled = true) {
+        when {
+            currentRoute == Screen.Meals.route -> {
+                (context as? android.app.Activity)?.finish()
+            }
+            else -> {
+                navController.popBackStack()
+            }
+        }
+    }
 
     Scaffold(
         bottomBar = {
@@ -57,13 +87,25 @@ fun AppContent() {
                             )
                         },
                         label = { Text(tab.label) },
-                        selected = tab == currentTab,
+                        selected = selectedTab == tab,
                         onClick = {
-                            currentTab = tab
-                            capturedPhotoUri = null
-                            showCamera = false
-                            editingMeal = null
-                            selectedConversationId = -1L
+                            when (tab) {
+                                AppTab.MEALS -> {
+                                    navController.popBackStack(Screen.Meals.route, inclusive = false)
+                                }
+                                AppTab.CHAT -> {
+                                    navController.navigate(Screen.ConversationsList.route) {
+                                        popUpTo(Screen.Meals.route)
+                                        launchSingleTop = true
+                                    }
+                                }
+                                AppTab.SETTINGS -> {
+                                    navController.navigate(Screen.Settings.route) {
+                                        popUpTo(Screen.Meals.route)
+                                        launchSingleTop = true
+                                    }
+                                }
+                            }
                         }
                     )
                 }
@@ -75,103 +117,145 @@ fun AppContent() {
                 .fillMaxSize()
                 .padding(innerPadding)
         ) {
-            when (currentTab) {
-                AppTab.MEALS -> {
-                    when {
-                        editingMeal != null -> {
-                            MealEditScreen(
-                                photoUri = editingMeal!!.meal.photoUri,
-                                existingMeal = editingMeal,
-                                onUpdate = { description, components ->
-                                    mealViewModel.updateMeal(
-                                        mealId = editingMeal!!.meal.id,
-                                        description = description,
-                                        components = components,
-                                        timestamp = editingMeal!!.meal.timestamp
-                                    )
-                                    editingMeal = null
-                                },
-                                onDelete = {
-                                    mealViewModel.deleteMeal(editingMeal!!.meal.id)
-                                    editingMeal = null
-                                },
-                                onRetake = { editingMeal = null }
-                            )
-                        }
-                        capturedPhotoUri != null -> {
-                            MealEditScreen(
-                                photoUri = capturedPhotoUri!!,
-                                onUpdate = { description, components ->
-                                    mealViewModel.saveMeal(
-                                        photoUri = capturedPhotoUri!!,
-                                        description = description,
-                                        components = components
-                                    )
-                                    capturedPhotoUri = null
-                                    showCamera = false
-                                },
-                                onDelete = { },
-                                onRetake = { capturedPhotoUri = null }
-                            )
-                        }
-                        showCamera -> {
-                            ScanMealScreen(
-                                onPhotoCaptured = { uri ->
-                                    capturedPhotoUri = uri
-                                    showCamera = false
-                                }
-                            )
-                        }
-                        else -> {
-                            MealsScreen(
-                                mealViewModel = mealViewModel,
-                                settingsViewModel = settingsViewModel,
-                                onAddMealClick = {
-                                    showCamera = true
-                                },
-                                onMealClick = { meal ->
-                                    editingMeal = meal
-                                }
-                            )
-                        }
-                    }
-                }
-
-                AppTab.CHAT -> {
-                    if (selectedConversationId > 0) {
-                        ChatScreen(
-                            conversationId = selectedConversationId,
-                            viewModel = chatViewModel,
-                            onBackClick = { selectedConversationId = -1L }
-                        )
-                    } else {
-                        ConversationsListScreen(
-                            viewModel = chatViewModel,
-                            onConversationClick = { conversationId ->
-                                selectedConversationId = conversationId
-                            },
-                            onNewConversation = { newId ->
-                                selectedConversationId = newId
-                            }
-                        )
-                    }
-                }
-
-                AppTab.SETTINGS -> {
-                    SettingsScreen(
-                        viewModel = settingsViewModel
-                    )
-                }
-            }
+            AppNavHost(
+                navController = navController,
+                mealViewModel = mealViewModel,
+                chatViewModel = chatViewModel,
+                settingsViewModel = settingsViewModel
+            )
         }
     }
 }
 
-enum class AppTab(
-    val label: String,
-    val icon: ImageVector,
+@Composable
+private fun AppNavHost(
+    navController: NavHostController,
+    mealViewModel: MealViewModel,
+    chatViewModel: ChatViewModel,
+    settingsViewModel: SettingsViewModel,
+    modifier: Modifier = Modifier
 ) {
-    MEALS("Meals", Icons.Default.List),
-    CHAT("Chat", Icons.Default.Email),
-    SETTINGS("Settings", Icons.Default.Settings),
+    NavHost(
+        navController = navController,
+        startDestination = Screen.Meals.route,
+        modifier = modifier
+    ) {
+        composable(Screen.Meals.route) {
+            MealsScreen(
+                mealViewModel = mealViewModel,
+                settingsViewModel = settingsViewModel,
+                onAddMealClick = {
+                    navController.navigate(Screen.ScanMeal.route)
+                },
+                onMealClick = { meal ->
+                    navController.navigate(Screen.MealEdit.createRoute(meal.meal.id))
+                }
+            )
+        }
+
+        composable(Screen.ScanMeal.route) {
+            ScanMealScreen(
+                onPhotoCaptured = { uri ->
+                    navController.navigate(Screen.MealEdit.createRoute(null)) {
+                        popUpTo(Screen.Meals.route)
+                    }
+                    mealViewModel.setPendingPhotoUri(uri)
+                }
+            )
+        }
+
+        composable(
+            route = Screen.MealEdit.route,
+            arguments = listOf(
+                navArgument(Screen.MealEdit.MEAL_ID_ARG) {
+                    type = NavType.LongType
+                    defaultValue = -1L
+                }
+            )
+        ) { backStackEntry ->
+            val mealId = backStackEntry.arguments?.getLong(Screen.MealEdit.MEAL_ID_ARG) ?: -1L
+            val pendingPhotoUri by mealViewModel.pendingPhotoUri.collectAsState()
+            var existingMeal by remember { mutableStateOf<MealWithComponents?>(null) }
+            val scope = rememberCoroutineScope()
+
+            LaunchedEffect(mealId) {
+                if (mealId > 0) {
+                    existingMeal = mealViewModel.getMealById(mealId)
+                }
+            }
+
+            val currentPendingPhoto = pendingPhotoUri
+            val currentExistingMeal = existingMeal
+
+            if (currentExistingMeal != null || currentPendingPhoto != null) {
+                MealEditScreen(
+                    photoUri = currentExistingMeal?.meal?.photoUri ?: currentPendingPhoto!!,
+                    existingMeal = currentExistingMeal,
+                    onUpdate = { description, components ->
+                        if (currentExistingMeal != null) {
+                            mealViewModel.updateMeal(
+                                mealId = currentExistingMeal.meal.id,
+                                description = description,
+                                components = components,
+                                timestamp = currentExistingMeal.meal.timestamp
+                            )
+                        } else {
+                            mealViewModel.saveMeal(
+                                photoUri = currentPendingPhoto!!,
+                                description = description,
+                                components = components
+                            )
+                        }
+                        mealViewModel.clearPendingPhoto()
+                        navController.popBackStack(Screen.Meals.route, inclusive = false)
+                    },
+                    onDelete = {
+                        if (currentExistingMeal != null) {
+                            mealViewModel.deleteMeal(currentExistingMeal.meal.id)
+                        }
+                        mealViewModel.clearPendingPhoto()
+                        navController.popBackStack(Screen.Meals.route, inclusive = false)
+                    },
+                    onRetake = {
+                        mealViewModel.clearPendingPhoto()
+                        navController.popBackStack()
+                    }
+                )
+            }
+        }
+
+        composable(Screen.ConversationsList.route) {
+            ConversationsListScreen(
+                viewModel = chatViewModel,
+                onConversationClick = { conversationId ->
+                    navController.navigate(Screen.Chat.createRoute(conversationId))
+                },
+                onNewConversation = { newId ->
+                    navController.navigate(Screen.Chat.createRoute(newId))
+                }
+            )
+        }
+
+        composable(
+            route = Screen.Chat.route,
+            arguments = listOf(
+                navArgument(Screen.Chat.CONVERSATION_ID_ARG) {
+                    type = NavType.LongType
+                }
+            )
+        ) { backStackEntry ->
+            val conversationId = backStackEntry.arguments?.getLong(Screen.Chat.CONVERSATION_ID_ARG) ?: return@composable
+            ChatScreen(
+                conversationId = conversationId,
+                viewModel = chatViewModel,
+                onBackClick = { navController.popBackStack() }
+            )
+        }
+
+        composable(Screen.Settings.route) {
+            SettingsScreen(
+                viewModel = settingsViewModel
+            )
+        }
+    }
 }

--- a/app/src/main/java/pro/trousev/mealcontrol/Navigation.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/Navigation.kt
@@ -1,0 +1,38 @@
+package pro.trousev.mealcontrol
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.ui.graphics.vector.ImageVector
+
+sealed class Screen(val route: String) {
+    data object Meals : Screen("meals")
+    data object ScanMeal : Screen("scan_meal")
+    data object MealEdit : Screen("meal_edit/{mealId}") {
+        fun createRoute(mealId: Long?) = "meal_edit/${mealId ?: -1}"
+        const val MEAL_ID_ARG = "mealId"
+    }
+    data object ConversationsList : Screen("conversations")
+    data object Chat : Screen("chat/{conversationId}") {
+        fun createRoute(conversationId: Long) = "chat/$conversationId"
+        const val CONVERSATION_ID_ARG = "conversationId"
+    }
+    data object Settings : Screen("settings")
+}
+
+enum class AppTab(
+    val route: String,
+    val label: String,
+    val icon: ImageVector,
+) {
+    MEALS(Screen.Meals.route, "Meals", Icons.Default.List),
+    CHAT(Screen.ConversationsList.route, "Chat", Icons.Default.Email),
+    SETTINGS(Screen.Settings.route, "Settings", Icons.Default.Settings),
+}
+
+fun AppTab.toScreen(): Screen = when (this) {
+    AppTab.MEALS -> Screen.Meals
+    AppTab.CHAT -> Screen.ConversationsList
+    AppTab.SETTINGS -> Screen.Settings
+}

--- a/app/src/main/java/pro/trousev/mealcontrol/viewmodel/MealViewModel.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/viewmodel/MealViewModel.kt
@@ -22,6 +22,9 @@ class MealViewModel(application: Application) : AndroidViewModel(application) {
     private val _todayMeals = MutableStateFlow<List<MealWithComponents>>(emptyList())
     val todayMeals: StateFlow<List<MealWithComponents>> = _todayMeals.asStateFlow()
 
+    private val _pendingPhotoUri = MutableStateFlow<String?>(null)
+    val pendingPhotoUri: StateFlow<String?> = _pendingPhotoUri.asStateFlow()
+
     init {
         viewModelScope.launch {
             loadMeals()
@@ -73,5 +76,17 @@ class MealViewModel(application: Application) : AndroidViewModel(application) {
             repository.updateMeal(mealId, description, components, timestamp)
             loadMeals()
         }
+    }
+
+    fun setPendingPhotoUri(uri: String) {
+        _pendingPhotoUri.value = uri
+    }
+
+    fun clearPendingPhoto() {
+        _pendingPhotoUri.value = null
+    }
+
+    suspend fun getMealById(mealId: Long): MealWithComponents? {
+        return repository.getMealById(mealId)
     }
 }

--- a/app/src/test/java/pro/trousev/mealcontrol/data/repository/MealRepositoryTest.kt
+++ b/app/src/test/java/pro/trousev/mealcontrol/data/repository/MealRepositoryTest.kt
@@ -33,9 +33,9 @@ class MealRepositoryTest {
         val photoUri = "content://photo/123"
         val description = "Lunch"
         val components = listOf(
-            Triple("Chicken", 150, listOf(300, 30, 10, 0)),
-            Triple("Rice", 100, listOf(200, 4, 1, 45)),
-            Triple("Salad", 50, listOf(20, 1, 0, 4))
+            Triple("Chicken", 150.0, listOf<Number>(300, 30, 10, 0)),
+            Triple("Rice", 100.0, listOf<Number>(200, 4, 1, 45)),
+            Triple("Salad", 50.0, listOf<Number>(20, 1, 0, 4))
         )
 
         val mealId = repository.saveMeal(photoUri, description, components)
@@ -58,11 +58,11 @@ class MealRepositoryTest {
 
     @Test
     fun getAllMeals_returnsMealsSortedByTimestamp() = runBlocking {
-        repository.saveMeal("photo1", "Meal 1", listOf(Triple("A", 100, listOf(100, 10, 5, 5))))
+        repository.saveMeal("photo1", "Meal 1", listOf(Triple("A", 100.0, listOf<Number>(100, 10, 5, 5))))
         Thread.sleep(10)
-        repository.saveMeal("photo2", "Meal 2", listOf(Triple("B", 200, listOf(200, 20, 10, 10))))
+        repository.saveMeal("photo2", "Meal 2", listOf(Triple("B", 200.0, listOf<Number>(200, 20, 10, 10))))
         Thread.sleep(10)
-        repository.saveMeal("photo3", "Meal 3", listOf(Triple("C", 300, listOf(300, 30, 15, 15))))
+        repository.saveMeal("photo3", "Meal 3", listOf(Triple("C", 300.0, listOf<Number>(300, 30, 15, 15))))
 
         val meals = repository.getAllMeals()
 
@@ -74,7 +74,7 @@ class MealRepositoryTest {
 
     @Test
     fun getMealById_returnsCorrectMeal() = runBlocking {
-        val mealId = repository.saveMeal("photo", "Dinner", listOf(Triple("Beef", 250, listOf(500, 40, 30, 0))))
+        val mealId = repository.saveMeal("photo", "Dinner", listOf(Triple("Beef", 250.0, listOf<Number>(500, 40, 30, 0))))
 
         val meal = repository.getMealById(mealId)
 
@@ -91,7 +91,7 @@ class MealRepositoryTest {
 
     @Test
     fun deleteMeal_removesMealAndComponents() = runBlocking {
-        val mealId = repository.saveMeal("photo", "Lunch", listOf(Triple("A", 100, listOf(100, 10, 5, 5))))
+        val mealId = repository.saveMeal("photo", "Lunch", listOf(Triple("A", 100.0, listOf<Number>(100, 10, 5, 5))))
 
         repository.deleteMeal(mealId)
 
@@ -111,7 +111,7 @@ class MealRepositoryTest {
 
     @Test
     fun saveMeal_withManyComponents_works() = runBlocking {
-        val manyComponents = (1..100).map { Triple("Component $it", it * 10, listOf(it * 10, it, it, it)) }
+        val manyComponents = (1..100).map { Triple("Component $it", (it * 10).toDouble(), listOf<Number>(it * 10, it, it, it)) }
         val mealId = repository.saveMeal("photo", "Many components", manyComponents)
 
         val meal = repository.getMealById(mealId)
@@ -126,9 +126,9 @@ class MealRepositoryTest {
             "photo",
             "Test",
             listOf(
-                Triple("Apple", 100, listOf(100, 0, 0, 25)),
-                Triple("Banana", 150, listOf(150, 1, 0, 38)),
-                Triple("Orange", 80, listOf(80, 1, 0, 20))
+                Triple("Apple", 100.0, listOf<Number>(100, 0, 0, 25)),
+                Triple("Banana", 150.0, listOf<Number>(150, 1, 0, 38)),
+                Triple("Orange", 80.0, listOf<Number>(80, 1, 0, 20))
             )
         )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ robolectric = "4.14"
 openai = "4.0.1"
 ktor = "3.0.3"
 exif = "1.3.7"
+navigationCompose = "2.8.5"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -54,6 +55,7 @@ openai-client = { group = "com.aallam.openai", name = "openai-client", version.r
 ktor-bom = { group = "io.ktor", name = "ktor-bom", version.ref = "ktor" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.6.0" }
 androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exif" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Implement proper navigation routing using Compose Navigation library
- MealsScreen is now root destination (back exits app)
- Photo picker and Meal Editor are children of MealsScreen
- Chat's back leads to conversations list
- Conversations list and settings back leads to MealsScreen
- Add pending photo state to MealViewModel for photo capture flow
- Fix test type mismatches (Int -> Double/Number)

## Back Stack Behavior
- **MealsScreen** → back exits app (root destination)
- **Photo picker** → back returns to MealsScreen
- **Meal Editor** → back returns to MealsScreen
- **ConversationsList** → back returns to MealsScreen
- **Chat** → back returns to ConversationsList
- **Settings** → back returns to MealsScreen