### PR TITLE
fix: prevent crash when sending followup after clarification

### DIFF
--- a/app/src/main/java/pro/trousev/mealcontrol/viewmodel/MealDetectionViewModel.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/viewmodel/MealDetectionViewModel.kt
@@ -208,6 +208,7 @@ class MealDetectionViewModel(application: Application) : AndroidViewModel(applic
                 error = null
             )
         } else if (followup.isNotEmpty()) {
+            val resultJson = Json.encodeToString(MealDetectionResult.serializer(), result)
             _state.value = _state.value.copy(
                 messages = _state.value.messages + MealDetectionMessage(
                     content = messageContent,
@@ -217,7 +218,7 @@ class MealDetectionViewModel(application: Application) : AndroidViewModel(applic
                 currentQuestion = followup,
                 currentComponents = null,
                 mealName = null,
-                lastResponseJson = _state.value.lastResponseJson,
+                lastResponseJson = resultJson,
                 isLoading = false,
                 error = null
             )


### PR DESCRIPTION
## Summary
- Fix crash when user sends followup after AI returns a clarification question (no food detected)
- Previously `lastResponseJson` was not set in clarification branch, causing subsequent API calls to send empty image

## Bug
1. Take photo of non-food item
2. Receive clarification question from AI
3. Send followup response
4. CRASH - empty image sent to API, unexpected response format

## Fix
Set `lastResponseJson` in the clarification branch (mirrors behavior of food-detected branch)