### PR TITLE
Fix AGENTS.md and add lint scripts with ktlint/detekt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*.kt]
+indent_size = 4
+indent_style = space
+max_line_length = off
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+
+ktlint_code_style = kotlin
+
+ktlint_disabled_rules = no-wildcard-imports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,36 +3,55 @@
 ## Project Overview
 MealControl is an Android application built with Kotlin and Jetpack Compose. It manages meals and includes a chat feature.
 
-## Build Commands
-
-### Build
-- `./script/build` - Build debug APK (recommended, handles Java/Android SDK setup)
-- `./gradlew assembleDebug` - Build debug APK (requires manual JAVA_HOME/ANDROID_HOME setup)
-- `./gradlew assembleRelease` - Build release APK
-
-**IMPORTANT**: Always use `./script/build` for compilation. Do NOT attempt to install any packages, find custom Java installations, or set up the environment manually.
-
-### Build Environment
+## Build Environment
 All build operations require Java and Android SDK to be configured via environment variables. These MUST be set in a `.env` file in the project root:
 - `JAVA_HOME` - Path to Java installation
 - `ANDROID_ROOT` - Path to Android SDK
 
 If the `.env` file is missing or does not contain valid paths, inform the user that building is not possible and ask them to set up the environment.
 
-### Run Tests
-- `./gradlew test` - Run unit tests
-- `./gradlew testDebugUnitTest` - Run unit tests for debug variant
-- `./gradlew testReleaseUnitTest` - Run unit tests for release variant
-- `./gradlew connectedAndroidTest` - Run instrumented tests (requires emulator/device)
-- `./gradlew testDebugUnitTest --tests "pro.trousev.mealcontrol.ExampleUnitTest"` - Run a single unit test class
+## Available Scripts
 
-### Lint
-- `./gradlew lint` - Run lint analysis
-- `./gradlew lintDebug` - Run lint on debug variant
+**IMPORTANT**: ALWAYS use `./script/*` commands. Never run `./gradlew` directly. All scripts automatically load environment variables from `.env`.
 
-### Other Commands
-- `./gradlew clean` - Clean build artifacts
-- `./gradlew build` - Full build with tests and lint
+| Script | Description |
+|--------|-------------|
+| `./script/build [--debug\|--release]` | Build APK |
+| `./script/run [--debug\|--release]` | Build + install to device + launch + logcat |
+| `./script/test [TestClass]` | Run unit tests (optional: specify fully-qualified class name) |
+| `./script/lint [--all]` | Run Android Lint, ktlint, and detekt (default: debug variant) |
+| `./script/update` | Check/update dependencies |
+
+### Script Details
+
+#### Build
+```bash
+./script/build           # Build debug APK
+./script/build --release # Build release APK
+```
+
+#### Run
+```bash
+./script/run              # Build debug + install + launch + logcat
+./script/run --release    # Same for release variant
+```
+
+#### Test
+```bash
+./script/test                            # Run all unit tests
+./script/test "pro.trousev.mealcontrol.ExampleUnitTest"  # Run specific test class
+```
+
+#### Lint
+```bash
+./script/lint           # Run lint on debug variant (Android Lint + ktlint + detekt)
+./script/lint --all     # Run lint on all variants
+```
+
+#### Update
+```bash
+./script/update         # Check dependency tree
+```
 
 ## Code Style Guidelines
 
@@ -147,7 +166,7 @@ abstract class MealControlDatabase : RoomDatabase() {
 - Test classes should be named with `Test` suffix (e.g., `ExampleUnitTest`)
 - Test ViewModels to verify state changes, calculations, and business logic
 - Test repositories to verify data operations
-- Run tests before committing: `./script/test`
+- Run tests before committing: `./script/test` (see Available Scripts section above)
 
 ### Gradle Configuration
 - Uses Kotlin DSL (`*.gradle.kts` files)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ktlint)
+    alias(libs.plugins.detekt)
 }
 
 android {
@@ -64,6 +66,25 @@ android {
     buildFeatures {
         compose = true
     }
+}
+
+ktlint {
+    version.set(libs.versions.ktlint.get())
+    android.set(true)
+    outputColorName.set("ANSI_GREEN")
+    reporters {
+        reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.CHECKSTYLE)
+        reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.SARIF)
+    }
+}
+
+detekt {
+    toolVersion.set(libs.versions.detekt.get())
+    config.set(files("$projectDir/config/detekt/detekt.yml"))
+    source.set(files("$projectDir/src"))
+    buildUponDefaultConfig.set(true)
+    allRules.set(false)
+    parallel.set(true)
 }
 
 dependencies {

--- a/app/config/detekt/detekt.yml
+++ b/app/config/detekt/detekt.yml
@@ -1,0 +1,181 @@
+comments:
+  active: true
+  EndOfFile:
+    active: true
+  UndocumentedPublicClass:
+    active: false
+  UndocumentedPublicFunction:
+    active: false
+
+complexity:
+  active: true
+  LongMethod:
+    active: true
+    threshold: 60
+  LongParameterList:
+    active: true
+    threshold: 8
+  TooManyFunctions:
+    active: true
+    thresholdInFiles: 25
+    thresholdInClasses: 20
+    thresholdInInterfaces: 15
+    thresholdInObjects: 15
+    thresholdInEnums: 10
+
+empty-blocks:
+  active: true
+
+exceptions:
+  active: true
+
+formatting:
+  active: true
+  AnnotationSpacing:
+    active: false
+  BlockCommentInitialStarAlignment:
+    active: false
+  DiscouragedCommentLocation:
+    active: false
+  EnumEntryNameCase:
+    active: true
+  EqualsOnSignatureLine:
+    active: false
+  Filename:
+    active: true
+  FunctionReturnTypeWrapping:
+    active: false
+  ImportOrdering:
+    active: true
+  ModifierOrder:
+    active: true
+  MultiLineIfElse:
+    active: false
+  NoBlankLineBeforeRbrace:
+    active: false
+  NoConsecutiveBlankLines:
+    active: true
+  NoLinePrefixLogging:
+    active: true
+  PackageNaming:
+    active: true
+  ParameterListWrapping:
+    active: false
+  ParameterWrapping:
+    active: false
+  PropertyNaming:
+    active: true
+  TrailComma:
+    active: false
+  TypeParameterListWrapping:
+    active: false
+  UseRequire:
+    active: false
+  Wrapping:
+    active: false
+
+naming:
+  active: true
+  ClassNaming:
+    active: true
+    classPattern: '[A-Z][a-zA-Z0-9]*'
+  ConstructorParameterNaming:
+    active: true
+  EnumNaming:
+    active: true
+    enumEntryPattern: '[A-Z][A-Za-z0-9]*'
+  FunctionNaming:
+    active: true
+    functionPattern: '[a-z][a-zA-Z0-9]*'
+  FunctionParameterNaming:
+    active: true
+  PropertyNaming:
+    active: true
+    propertyPattern: '[a-z][A-Za-z0-9]*'
+
+performance:
+  active: true
+
+potential-bugs:
+  active: true
+  MissingWhenCase:
+    active: true
+  NullableToStringCall:
+    active: false
+  UnreachableCode:
+    active: true
+
+style:
+  active: true
+  ClassOrdering:
+    active: true
+  CollapsibleIfStatements:
+    active: true
+  DataClassShouldBeImmutable:
+    active: false
+  EqualsNullCall:
+    active: true
+  ExplicitCollectionElementAccessMethod:
+    active: false
+  ExpressionBodySyntax:
+    active: false
+  ForbiddenComment:
+    active: false
+  ForbiddenImport:
+    active: false
+  FunctionOnlyReadingConstants:
+    active: false
+  LibraryCodeShouldSpecifyReturnType:
+    active: false
+  MagicNumber:
+    active: false
+  MandatoryBracesIfStatements:
+    active: false
+  MaxLineLength:
+    active: false
+  ModifierOrdering:
+    active: false
+  NoTabs:
+    active: false
+  OptionalUnit:
+    active: false
+  OptionalWhenBraces:
+    active: false
+  PreferToOverPairSyntax:
+    active: false
+  ProtectedMemberInFinalClass:
+    active: true
+  SerialVersionUIDInSerializableClass:
+    active: false
+  SpacingBetweenPackageAndImports:
+    active: false
+  ThrowsCountExceeded:
+    active: false
+  TrailingWhitespace:
+    active: false
+  UnderscoresInNumericLiterals:
+    active: false
+  UnusedPrivateMember:
+    active: true
+  UseArrayLiteralsInAnnotations:
+    active: false
+  UseCheckNotIn:
+    active: false
+  UseDataClass:
+    active: false
+  UseIfInsteadOfWhen:
+    active: false
+  UseIsNullOrEmpty:
+    active: true
+  UseOrEmpty:
+    active: false
+  UseRequireNotNull:
+    active: false
+  UselessCallOnNotNull:
+    active: true
+  UtilityClassWithPublicConstructor:
+    active: true
+  VarCouldBeVal:
+    active: true
+  WildcardImport:
+    active: false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.ktlint) apply false
+    alias(libs.plugins.detekt) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,8 @@ openai = "4.0.1"
 ktor = "3.0.3"
 exif = "1.3.7"
 navigationCompose = "2.8.5"
+ktlint = "1.3.0"
+detekt = "1.23.7"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -62,3 +64,5 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/script/lint
+++ b/script/lint
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/.."
+
+if [ -f .env ]; then
+    source .env
+fi
+
+export JAVA_HOME
+export ANDROID_HOME
+
+VARIANT="debug"
+ALL_VARIANTS=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --all)
+            ALL_VARIANTS=true
+            shift
+            ;;
+        --release)
+            VARIANT="release"
+            shift
+            ;;
+        --debug)
+            VARIANT="debug"
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--debug|--release|--all]"
+            exit 1
+            ;;
+    esac
+done
+
+echo "Running lint checks..."
+
+if [ "$ALL_VARIANTS" = true ]; then
+    echo "Running lint on all variants..."
+    ./gradlew lint
+else
+    echo "Running lint on ${VARIANT} variant..."
+    ./gradlew lint${VARIANT^}
+fi
+
+echo ""
+echo "Running ktlint..."
+./gradlew ktlintCheck
+
+echo ""
+echo "Running detekt..."
+./gradlew detekt
+
+echo ""
+echo "Lint complete!"


### PR DESCRIPTION
## Summary
- Fix AGENTS.md: remove direct `./gradlew` references, consolidate into "Available Scripts" section
- Add `./script/lint` with support for `--all` flag to run all variants
- Add ktlint 1.3.0 for Kotlin code style checking
- Add detekt 1.23.7 for static code analysis
- Add `.editorconfig` for ktlint configuration
- Add `config/detekt/detekt.yml` for detekt configuration