### PR TITLE
Visual polish: app icon, splash screen, and brand theming

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,6 +118,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.exifinterface)
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.splashscreen)
     testImplementation(libs.junit)
     testImplementation(libs.androidx.room.runtime)
     testImplementation(libs.androidx.room.ktx)

--- a/app/src/main/java/pro/trousev/mealcontrol/AppContent.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/AppContent.kt
@@ -82,7 +82,7 @@ fun AppContent() {
                     NavigationBarItem(
                         icon = {
                             Icon(
-                                tab.icon,
+                                imageVector = tab.icon,
                                 contentDescription = tab.label
                             )
                         },

--- a/app/src/main/java/pro/trousev/mealcontrol/MainActivity.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/MainActivity.kt
@@ -4,10 +4,12 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import pro.trousev.mealcontrol.ui.theme.MealControlTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {

--- a/app/src/main/java/pro/trousev/mealcontrol/Navigation.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/Navigation.kt
@@ -1,8 +1,8 @@
 package pro.trousev.mealcontrol
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Email
-import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
 
@@ -26,9 +26,9 @@ enum class AppTab(
     val label: String,
     val icon: ImageVector,
 ) {
-    MEALS(Screen.Meals.route, "Meals", Icons.Default.List),
-    CHAT(Screen.ConversationsList.route, "Chat", Icons.Default.Email),
-    SETTINGS(Screen.Settings.route, "Settings", Icons.Default.Settings),
+    MEALS(Screen.Meals.route, "Meals", Icons.AutoMirrored.Filled.List),
+    CHAT(Screen.ConversationsList.route, "Chat", Icons.Filled.Email),
+    SETTINGS(Screen.Settings.route, "Settings", Icons.Filled.Settings),
 }
 
 fun AppTab.toScreen(): Screen = when (this) {

--- a/app/src/main/java/pro/trousev/mealcontrol/ui/scanmeal/ScanMealScreen.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/scanmeal/ScanMealScreen.kt
@@ -150,7 +150,7 @@ fun ScanMealScreen(
                         modifier = Modifier.size(72.dp)
                     ) {
                         Icon(
-                            imageVector = Icons.Default.Add,
+                            imageVector = Icons.Filled.Add,
                             contentDescription = "Capture",
                             modifier = Modifier.size(36.dp)
                         )

--- a/app/src/main/java/pro/trousev/mealcontrol/ui/theme/Color.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/theme/Color.kt
@@ -2,10 +2,79 @@ package pro.trousev.mealcontrol.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+// Warm brand palette for MealControl
+val WarmOrange = Color(0xFFFF7043)
+val WarmOrangeLight = Color(0xFFFFAB91)
+val WarmOrangeDark = Color(0xFFE64A19)
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+val FreshGreen = Color(0xFF66BB6A)
+val FreshGreenLight = Color(0xFFA5D6A7)
+val FreshGreenDark = Color(0xFF388E3C)
+
+val Cream = Color(0xFFFFF8E1)
+val CreamDark = Color(0xFFFFECB3)
+
+val DeepBrown = Color(0xFF5D4037)
+val DeepBrownLight = Color(0xFF8D6E63)
+
+// Neutral surfaces
+val SurfaceLight = Color(0xFFFFFBF5)
+val SurfaceDark = Color(0xFF1C1B1E)
+
+// Light theme
+val md_theme_light_primary = WarmOrange
+val md_theme_light_onPrimary = Color.White
+val md_theme_light_primaryContainer = Color(0xFFFFDBD0)
+val md_theme_light_onPrimaryContainer = Color(0xFF3A0B00)
+val md_theme_light_secondary = FreshGreen
+val md_theme_light_onSecondary = Color.White
+val md_theme_light_secondaryContainer = Color(0xFFC8E6C9)
+val md_theme_light_onSecondaryContainer = Color(0xFF1B5E20)
+val md_theme_light_tertiary = DeepBrown
+val md_theme_light_onTertiary = Color.White
+val md_theme_light_tertiaryContainer = Cream
+val md_theme_light_onTertiaryContainer = Color(0xFF3E2723)
+val md_theme_light_error = Color(0xFFBA1A1A)
+val md_theme_light_errorContainer = Color(0xFFFFDAD6)
+val md_theme_light_onError = Color.White
+val md_theme_light_onErrorContainer = Color(0xFF410002)
+val md_theme_light_background = SurfaceLight
+val md_theme_light_onBackground = Color(0xFF201A19)
+val md_theme_light_surface = SurfaceLight
+val md_theme_light_onSurface = Color(0xFF201A19)
+val md_theme_light_surfaceVariant = Color(0xFFF5DED6)
+val md_theme_light_onSurfaceVariant = Color(0xFF53433E)
+val md_theme_light_outline = Color(0xFF85736C)
+val md_theme_light_inverseOnSurface = Color(0xFFFBEEE9)
+val md_theme_light_inverseSurface = Color(0xFF362F2D)
+val md_theme_light_inversePrimary = Color(0xFFFFB59D)
+val md_theme_light_surfaceTint = WarmOrange
+
+// Dark theme
+val md_theme_dark_primary = Color(0xFFFFB59D)
+val md_theme_dark_onPrimary = Color(0xFF5F1500)
+val md_theme_dark_primaryContainer = WarmOrangeDark
+val md_theme_dark_onPrimaryContainer = Color(0xFFFFDBD0)
+val md_theme_dark_secondary = Color(0xFFA5D6A7)
+val md_theme_dark_onSecondary = Color(0xFF1B5E20)
+val md_theme_dark_secondaryContainer = FreshGreenDark
+val md_theme_dark_onSecondaryContainer = Color(0xFFC8E6C9)
+val md_theme_dark_tertiary = Color(0xFFBCAAA4)
+val md_theme_dark_onTertiary = Color(0xFF2C1F1B)
+val md_theme_dark_tertiaryContainer = DeepBrownLight
+val md_theme_dark_onTertiaryContainer = CreamDark
+val md_theme_dark_error = Color(0xFFFFB4AB)
+val md_theme_dark_errorContainer = Color(0xFF93000A)
+val md_theme_dark_onError = Color(0xFF690005)
+val md_theme_dark_onErrorContainer = Color(0xFFFFDAD6)
+val md_theme_dark_background = SurfaceDark
+val md_theme_dark_onBackground = Color(0xFFEDE0DC)
+val md_theme_dark_surface = SurfaceDark
+val md_theme_dark_onSurface = Color(0xFFEDE0DC)
+val md_theme_dark_surfaceVariant = Color(0xFF53433E)
+val md_theme_dark_onSurfaceVariant = Color(0xFFD8C2BB)
+val md_theme_dark_outline = Color(0xFFA08D86)
+val md_theme_dark_inverseOnSurface = Color(0xFF201A19)
+val md_theme_dark_inverseSurface = Color(0xFFEDE0DC)
+val md_theme_dark_inversePrimary = WarmOrange
+val md_theme_dark_surfaceTint = Color(0xFFFFB59D)

--- a/app/src/main/java/pro/trousev/mealcontrol/ui/theme/Theme.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/theme/Theme.kt
@@ -9,34 +9,75 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
-
-private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
-)
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
+    primary = md_theme_light_primary,
+    onPrimary = md_theme_light_onPrimary,
+    primaryContainer = md_theme_light_primaryContainer,
+    onPrimaryContainer = md_theme_light_onPrimaryContainer,
+    secondary = md_theme_light_secondary,
+    onSecondary = md_theme_light_onSecondary,
+    secondaryContainer = md_theme_light_secondaryContainer,
+    onSecondaryContainer = md_theme_light_onSecondaryContainer,
+    tertiary = md_theme_light_tertiary,
+    onTertiary = md_theme_light_onTertiary,
+    tertiaryContainer = md_theme_light_tertiaryContainer,
+    onTertiaryContainer = md_theme_light_onTertiaryContainer,
+    error = md_theme_light_error,
+    errorContainer = md_theme_light_errorContainer,
+    onError = md_theme_light_onError,
+    onErrorContainer = md_theme_light_onErrorContainer,
+    background = md_theme_light_background,
+    onBackground = md_theme_light_onBackground,
+    surface = md_theme_light_surface,
+    onSurface = md_theme_light_onSurface,
+    surfaceVariant = md_theme_light_surfaceVariant,
+    onSurfaceVariant = md_theme_light_onSurfaceVariant,
+    outline = md_theme_light_outline,
+    inverseOnSurface = md_theme_light_inverseOnSurface,
+    inverseSurface = md_theme_light_inverseSurface,
+    inversePrimary = md_theme_light_inversePrimary,
+    surfaceTint = md_theme_light_surfaceTint
+)
 
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+private val DarkColorScheme = darkColorScheme(
+    primary = md_theme_dark_primary,
+    onPrimary = md_theme_dark_onPrimary,
+    primaryContainer = md_theme_dark_primaryContainer,
+    onPrimaryContainer = md_theme_dark_onPrimaryContainer,
+    secondary = md_theme_dark_secondary,
+    onSecondary = md_theme_dark_onSecondary,
+    secondaryContainer = md_theme_dark_secondaryContainer,
+    onSecondaryContainer = md_theme_dark_onSecondaryContainer,
+    tertiary = md_theme_dark_tertiary,
+    onTertiary = md_theme_dark_onTertiary,
+    tertiaryContainer = md_theme_dark_tertiaryContainer,
+    onTertiaryContainer = md_theme_dark_onTertiaryContainer,
+    error = md_theme_dark_error,
+    errorContainer = md_theme_dark_errorContainer,
+    onError = md_theme_dark_onError,
+    onErrorContainer = md_theme_dark_onErrorContainer,
+    background = md_theme_dark_background,
+    onBackground = md_theme_dark_onBackground,
+    surface = md_theme_dark_surface,
+    onSurface = md_theme_dark_onSurface,
+    surfaceVariant = md_theme_dark_surfaceVariant,
+    onSurfaceVariant = md_theme_dark_onSurfaceVariant,
+    outline = md_theme_dark_outline,
+    inverseOnSurface = md_theme_dark_inverseOnSurface,
+    inverseSurface = md_theme_dark_inverseSurface,
+    inversePrimary = md_theme_dark_inversePrimary,
+    surfaceTint = md_theme_dark_surfaceTint
 )
 
 @Composable
 fun MealControlTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
@@ -45,9 +86,17 @@ fun MealControlTheme(
             val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
-
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
+    }
+
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.statusBarColor = colorScheme.primary.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+        }
     }
 
     MaterialTheme(

--- a/app/src/main/java/pro/trousev/mealcontrol/ui/theme/Type.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/theme/Type.kt
@@ -6,22 +6,104 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-// Set of Material typography styles to start with
 val Typography = Typography(
+    displayLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 57.sp,
+        lineHeight = 64.sp,
+        letterSpacing = (-0.25).sp
+    ),
+    displayMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 45.sp,
+        lineHeight = 52.sp,
+        letterSpacing = 0.sp
+    ),
+    displaySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 36.sp,
+        lineHeight = 44.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 32.sp,
+        lineHeight = 40.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 28.sp,
+        lineHeight = 36.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 24.sp,
+        lineHeight = 32.sp,
+        letterSpacing = 0.sp
+    ),
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Bold,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.15.sp
+    ),
+    titleSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    ),
     bodyLarge = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp
-    )
-    /* Other default text styles to override
-    titleLarge = TextStyle(
+    ),
+    bodyMedium = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp
+    ),
+    bodySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.4.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    ),
+    labelMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
     ),
     labelSmall = TextStyle(
         fontFamily = FontFamily.Default,
@@ -30,5 +112,4 @@ val Typography = Typography(
         lineHeight = 16.sp,
         letterSpacing = 0.5.sp
     )
-    */
 )

--- a/app/src/main/res/drawable/ic_camera.xml
+++ b/app/src/main/res/drawable/ic_camera.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,15.2 A3.2,3.2 0,1 1,12,8.8 A3.2,3.2 0,1 1,12,15.2 M12,2 A10,10 0,0 0,2 12 A10,10 0,0 0,12 22 A10,10 0,0 0,22 12 A10,10 0,0 0,12 2 M12,4 A8,8 0,0 1,20 12 A8,8 0,0 1,12 20 A8,8 0,0 1,4 12 A8,8 0,0 1,12 4"/>
+</vector>

--- a/app/src/main/res/drawable/ic_chat.xml
+++ b/app/src/main/res/drawable/ic_chat.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M20,2 L4,2 C2.9,2 2,2.9 2,4 L2,22 L6,18 L20,18 C21.1,18 22,17.1 22,16 L22,4 C22,2.9 21.1,2 20,2 M20,16 L6,16 L4,18 L4,4 L20,4 L20,16 M8,14 L18,14 L18,12 L8,12 L8,14 M8,11 L18,11 L18,9 L8,9 L8,11"/>
+</vector>

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -4,167 +4,24 @@
     android:height="108dp"
     android:viewportWidth="108"
     android:viewportHeight="108">
+    <!-- Warm gradient background: cream to soft orange -->
     <path
-        android:fillColor="#3DDC84"
-        android:pathData="M0,0h108v108h-108z" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M9,0L9,108"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M19,0L19,108"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M29,0L29,108"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M39,0L39,108"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M49,0L49,108"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M59,0L59,108"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M69,0L69,108"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M79,0L79,108"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M89,0L89,108"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M99,0L99,108"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M0,9L108,9"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M0,19L108,19"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M0,29L108,29"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M0,39L108,39"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M0,49L108,49"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M0,59L108,59"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M0,69L108,69"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M0,79L108,79"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M0,89L108,89"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M0,99L108,99"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M19,29L89,29"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M19,39L89,39"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M19,49L89,49"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M19,59L89,59"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M19,69L89,69"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M19,79L89,79"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M29,19L29,89"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M39,19L39,89"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M49,19L49,89"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M59,19L59,89"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M69,19L69,89"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M79,19L79,89"
-        android:strokeWidth="0.8"
-        android:strokeColor="#33FFFFFF" />
+        android:pathData="M0,0h108v108h-108z">
+        <gradient
+            android:type="linear"
+            android:startX="0"
+            android:startY="0"
+            android:endX="108"
+            android:endY="108">
+            <item
+                android:offset="0"
+                android:color="#FFFBE6"/>
+            <item
+                android:offset="0.5"
+                android:color="#FFF3D6"/>
+            <item
+                android:offset="1"
+                android:color="#FFE8C2"/>
+        </gradient>
+    </path>
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,30 +1,46 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:aapt="http://schemas.android.com/aapt"
     android:width="108dp"
     android:height="108dp"
     android:viewportWidth="108"
     android:viewportHeight="108">
-    <path android:pathData="M31,63.928c0,0 6.4,-11 12.1,-13.1c7.2,-2.6 26,-1.4 26,-1.4l38.1,38.1L107,108.928l-32,-1L31,63.928z">
-        <aapt:attr name="android:fillColor">
-            <gradient
-                android:endX="85.84757"
-                android:endY="92.4963"
-                android:startX="42.9492"
-                android:startY="49.59793"
-                android:type="linear">
-                <item
-                    android:color="#44000000"
-                    android:offset="0.0" />
-                <item
-                    android:color="#00000000"
-                    android:offset="1.0" />
-            </gradient>
-        </aapt:attr>
-    </path>
+    <!-- Steam lines (wavy, rising) -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2.5"
+        android:strokeLineCap="round"
+        android:pathData="M40,35 Q44,28 40,22 Q36,16 40,10"/>
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2.5"
+        android:strokeLineCap="round"
+        android:pathData="M54,33 Q58,25 54,18 Q50,11 54,5"/>
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2.5"
+        android:strokeLineCap="round"
+        android:pathData="M68,35 Q72,28 68,22 Q64,16 68,10"/>
+    <!-- Bowl body -->
     <path
         android:fillColor="#FFFFFF"
-        android:fillType="nonZero"
-        android:pathData="M65.3,45.828l3.8,-6.6c0.2,-0.4 0.1,-0.9 -0.3,-1.1c-0.4,-0.2 -0.9,-0.1 -1.1,0.3l-3.9,6.7c-6.3,-2.8 -13.4,-2.8 -19.7,0l-3.9,-6.7c-0.2,-0.4 -0.7,-0.5 -1.1,-0.3C38.8,38.328 38.7,38.828 38.9,39.228l3.8,6.6C36.2,49.428 31.7,56.028 31,63.928h46C76.3,56.028 71.8,49.428 65.3,45.828zM43.4,57.328c-0.8,0 -1.5,-0.5 -1.8,-1.2c-0.3,-0.7 -0.1,-1.5 0.4,-2.1c0.5,-0.5 1.4,-0.7 2.1,-0.4c0.7,0.3 1.2,1 1.2,1.8C45.3,56.528 44.5,57.328 43.4,57.328L43.4,57.328zM64.6,57.328c-0.8,0 -1.5,-0.5 -1.8,-1.2s-0.1,-1.5 0.4,-2.1c0.5,-0.5 1.4,-0.7 2.1,-0.4c0.7,0.3 1.2,1 1.2,1.8C66.5,56.528 65.6,57.328 64.6,57.328L64.6,57.328z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M30,50 Q30,85 54,85 Q78,85 78,50 L78,45 Q78,40 73,40 L35,40 Q30,40 30,45 Z"/>
+    <!-- Bowl rim highlight -->
+    <path
+        android:fillColor="#E0E0E0"
+        android:pathData="M32,42 Q32,38 37,38 L71,38 Q76,38 76,42 L76,45 Q76,46 75,46 L33,46 Q32,46 32,45 Z"/>
+    <!-- Soup/surface (slight oval) -->
+    <path
+        android:fillColor="#FFCC80"
+        android:pathData="M33,48 Q33,44 38,44 L70,44 Q75,44 75,48 Q75,54 54,54 Q33,54 33,48 Z"/>
+    <!-- Steam glow effect -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.3"
+        android:pathData="M38,30 Q42,24 38,18 Q46,22 42,14 Q48,20 44,10"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.3"
+        android:pathData="M70,30 Q66,24 70,18 Q62,22 66,14 Q60,20 64,10"/>
 </vector>

--- a/app/src/main/res/drawable/ic_meal.xml
+++ b/app/src/main/res/drawable/ic_meal.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M12,3 C8,3 5,5 5,8 C5,10 6.5,12 8,13 L8,20 C8,21 9,22 10,22 L14,22 C15,22 16,21 16,20 L16,13 C17.5,12 19,10 19,8 C19,5 16,3 12,3 M12,5 C14.5,5 16,6.5 16,8 C16,9.5 14.5,11 12,11 C9.5,11 8,9.5 8,8 C8,6.5 9.5,5 12,5"/>
+</vector>

--- a/app/src/main/res/drawable/ic_settings.xml
+++ b/app/src/main/res/drawable/ic_settings.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M12,15.5 A3.5,3.5 0,1 1,12,8.5 A3.5,3.5 0,1 1,12,15.5 M12,4 C14.2,4 16,5.8 16,8 C16,10.2 14.2,12 12,12 C9.8,12 8,10.2 8,8 C8,5.8 9.8,4 12,4 M12,13 C16.4,13 20,14.3 20,16.25 L20,18 L4,18 L4,16.25 C4,14.3 7.6,13 12,13"/>
+</vector>

--- a/app/src/main/res/drawable/splash_background.xml
+++ b/app/src/main/res/drawable/splash_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background"/>
+</layer-list>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,6 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+
+    <color name="splash_status_bar">#FFE8C2</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <style name="Theme.MealControl" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.MealControl" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowBackground">@drawable/splash_background</item>
+        <item name="android:statusBarColor">@color/splash_status_bar</item>
+        <item name="android:navigationBarColor">@color/splash_status_bar</item>
+    </style>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ openai = "4.0.1"
 ktor = "3.0.3"
 exif = "1.3.7"
 navigationCompose = "2.8.5"
+splashscreen = "1.0.1"
 ktlint = "1.3.0"
 detekt = "1.23.7"
 
@@ -58,6 +59,7 @@ ktor-bom = { group = "io.ktor", name = "ktor-bom", version.ref = "ktor" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.6.0" }
 androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exif" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Add custom warm bowl app icon with steam
- Implement branded splash screen with Android 12+ API
- Add warm brand colors (orange/green palette)
- Update typography with full Material 3 scale
- Add custom navigation icons
- Update theme with proper light/dark support

## Changes
- Custom vector icon with bowl and steam motif
- Splash screen using androidx.core:core-splashscreen
- New Color.kt with warm orange (#FF7043) primary and fresh green (#66BB6A) secondary
- Full Material 3 typography scale in Type.kt
- Theme.kt updated with brand colors and dynamic color support
- Custom drawable icons for navigation tabs

## Testing
Build verified successfully.