### PR TITLE
Update detekt version to 1.23.8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ splashscreen = "1.0.1"
 securityCrypto = "1.1.0-alpha06"
 ktlint = "1.7.2"
 ktlintPlugin = "14.2.0"
-detekt = "1.23.7"
+detekt = "1.23.8"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
## Summary
- Update detekt version from 1.23.7 to 1.23.8 in version catalog