### PR TITLE
Hide results card in manual working mode

### DIFF
--- a/app/src/main/java/pro/trousev/mealcontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/settings/SettingsScreen.kt
@@ -374,7 +374,7 @@ fun SettingsScreen(
             }
         }
 
-        if (formState.calculation != null) {
+        if (formState.calculation != null && formState.workingMode != WorkingMode.MANUAL) {
             Spacer(modifier = Modifier.height(8.dp))
             ResultsCard(calculation = formState.calculation!!)
         }


### PR DESCRIPTION
## Summary
- Hide results card when working mode is set to MANUAL
- Results should only be shown when there's an active calculation and the user is not in manual input mode