### PR TITLE
Allow setting 0 as daily macro target in Manual Mode

### DIFF
--- a/app/src/main/java/pro/trousev/mealcontrol/AppContent.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/AppContent.kt
@@ -35,8 +35,11 @@ import pro.trousev.mealcontrol.ui.scanmeal.MealEditScreen
 import pro.trousev.mealcontrol.ui.scanmeal.ScanMealScreen
 import pro.trousev.mealcontrol.ui.settings.SettingsScreen
 import pro.trousev.mealcontrol.viewmodel.ChatViewModel
+import pro.trousev.mealcontrol.viewmodel.DailyBudget
+import pro.trousev.mealcontrol.viewmodel.DailyBudgetProvider
 import pro.trousev.mealcontrol.viewmodel.MealViewModel
 import pro.trousev.mealcontrol.viewmodel.SettingsViewModel
+import pro.trousev.mealcontrol.viewmodel.WorkingMode
 
 @Composable
 fun AppContent() {
@@ -171,7 +174,10 @@ private fun AppNavHost(
                     },
                 ),
         ) { backStackEntry ->
-            val mealId = backStackEntry.arguments?.getLong(Screen.MealEdit.MEAL_ID_ARG) ?: -1L
+            val mealId =
+                backStackEntry.arguments?.getLong(Screen.MealEdit.MEAL_ID_ARG)
+                    ?: -1L
+            val settingsState by settingsViewModel.formState.collectAsState()
             val pendingPhotoUri by mealViewModel.pendingPhotoUri.collectAsState()
             var existingMeal by remember { mutableStateOf<MealWithComponents?>(null) }
             val scope = rememberCoroutineScope()
@@ -186,9 +192,26 @@ private fun AppNavHost(
             val currentExistingMeal = existingMeal
 
             if (currentExistingMeal != null || currentPendingPhoto != null) {
+                val calculation = settingsState.calculation
+                val budget =
+                    calculation?.let {
+                        DailyBudget(
+                            calories = it.dailyCalories,
+                            protein = it.proteinGrams,
+                            fat = it.fatGrams,
+                            carbs = it.carbGrams,
+                        )
+                    } ?: DailyBudget(0, 0, 0, 0)
+                val isManual = settingsState.workingMode == WorkingMode.MANUAL
+                val showProteinFlag = DailyBudgetProvider.shouldShowProtein(isManual, budget)
+                val showFatFlag = DailyBudgetProvider.shouldShowFat(isManual, budget)
+                val showCarbsFlag = DailyBudgetProvider.shouldShowCarbs(isManual, budget)
                 MealEditScreen(
                     photoUri = currentExistingMeal?.meal?.photoUri ?: currentPendingPhoto!!,
                     existingMeal = currentExistingMeal,
+                    showProtein = showProteinFlag,
+                    showFat = showFatFlag,
+                    showCarbs = showCarbsFlag,
                     onUpdate = { description, components ->
                         if (currentExistingMeal != null) {
                             mealViewModel.updateMeal(

--- a/app/src/main/java/pro/trousev/mealcontrol/ui/meals/MealsScreen.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/meals/MealsScreen.kt
@@ -46,9 +46,12 @@ import coil.compose.rememberAsyncImagePainter
 import kotlinx.coroutines.launch
 import pro.trousev.mealcontrol.data.local.entity.MealComponentEntity
 import pro.trousev.mealcontrol.data.local.entity.MealWithComponents
+import pro.trousev.mealcontrol.viewmodel.DailyBudget
+import pro.trousev.mealcontrol.viewmodel.DailyBudgetProvider
 import pro.trousev.mealcontrol.viewmodel.DayNutrientTotals
 import pro.trousev.mealcontrol.viewmodel.MealViewModel
 import pro.trousev.mealcontrol.viewmodel.SettingsViewModel
+import pro.trousev.mealcontrol.viewmodel.WorkingMode
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -74,6 +77,14 @@ fun MealsScreen(
     val targetFat = settingsFormState.calculation?.fatGrams ?: 0
     val targetCarbs = settingsFormState.calculation?.carbGrams ?: 0
     val hideCalories = settingsFormState.hideCaloriesEnabled
+    val isManualMode = settingsFormState.workingMode == WorkingMode.MANUAL
+    val budget =
+        DailyBudget(
+            calories = targetCalories,
+            protein = targetProtein,
+            fat = targetFat,
+            carbs = targetCarbs,
+        )
 
     val pagerState =
         rememberPagerState(
@@ -111,6 +122,8 @@ fun MealsScreen(
                 targetFat = targetFat,
                 targetCarbs = targetCarbs,
                 hideCalories = hideCalories,
+                isManualMode = isManualMode,
+                budget = budget,
                 onAddMealClick = onAddMealClick,
                 onMealClick = onMealClick,
                 onGoToTodayClick = {
@@ -138,6 +151,8 @@ private fun DayPage(
     targetFat: Int,
     targetCarbs: Int,
     hideCalories: Boolean,
+    isManualMode: Boolean,
+    budget: DailyBudget,
     onAddMealClick: () -> Unit,
     onMealClick: (MealWithComponents) -> Unit,
     onGoToTodayClick: () -> Unit,
@@ -147,6 +162,9 @@ private fun DayPage(
     val remainingProtein = targetProtein - dayTotals.protein
     val remainingFat = targetFat - dayTotals.fat
     val remainingCarbs = targetCarbs - dayTotals.carbs
+    val showProtein = DailyBudgetProvider.shouldShowProtein(isManualMode, budget)
+    val showFat = DailyBudgetProvider.shouldShowFat(isManualMode, budget)
+    val showCarbs = DailyBudgetProvider.shouldShowCarbs(isManualMode, budget)
 
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
@@ -174,6 +192,9 @@ private fun DayPage(
                     targetCarbs = targetCarbs,
                     remainingCarbs = remainingCarbs,
                     hideCalories = hideCalories,
+                    showProtein = showProtein,
+                    showFat = showFat,
+                    showCarbs = showCarbs,
                 )
             }
 
@@ -198,6 +219,9 @@ private fun DayPage(
                         mealWithComponents = mealWithComponents,
                         totals = computeMealTotals(mealWithComponents.components),
                         hideCalories = hideCalories,
+                        showProtein = showProtein,
+                        showFat = showFat,
+                        showCarbs = showCarbs,
                         onClick = { onMealClick(mealWithComponents) },
                     )
                 }
@@ -259,6 +283,9 @@ private fun DaySummaryCard(
     targetCarbs: Int,
     remainingCarbs: Int,
     hideCalories: Boolean,
+    showProtein: Boolean,
+    showFat: Boolean,
+    showCarbs: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val dateFormat = remember { SimpleDateFormat("MMMM d, yyyy", Locale.US) }
@@ -294,21 +321,27 @@ private fun DaySummaryCard(
                     )
                     Spacer(modifier = Modifier.height(4.dp))
                 }
-                Text(
-                    text = if (remainingProtein >= 0) "$remainingProtein / ${targetProtein}g protein left" else "${-remainingProtein} / ${targetProtein}g protein over",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = if (remainingProtein < 0) overColor else MaterialTheme.colorScheme.onPrimaryContainer,
-                )
-                Text(
-                    text = if (remainingFat >= 0) "$remainingFat / ${targetFat}g fat left" else "${-remainingFat} / ${targetFat}g fat over",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = if (remainingFat < 0) overColor else MaterialTheme.colorScheme.onPrimaryContainer,
-                )
-                Text(
-                    text = if (remainingCarbs >= 0) "$remainingCarbs / ${targetCarbs}g carbs left" else "${-remainingCarbs} / ${targetCarbs}g carbs over",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = if (remainingCarbs < 0) overColor else MaterialTheme.colorScheme.onPrimaryContainer,
-                )
+                if (showProtein) {
+                    Text(
+                        text = if (remainingProtein >= 0) "$remainingProtein / ${targetProtein}g protein left" else "${-remainingProtein} / ${targetProtein}g protein over",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (remainingProtein < 0) overColor else MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+                if (showFat) {
+                    Text(
+                        text = if (remainingFat >= 0) "$remainingFat / ${targetFat}g fat left" else "${-remainingFat} / ${targetFat}g fat over",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (remainingFat < 0) overColor else MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+                if (showCarbs) {
+                    Text(
+                        text = if (remainingCarbs >= 0) "$remainingCarbs / ${targetCarbs}g carbs left" else "${-remainingCarbs} / ${targetCarbs}g carbs over",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (remainingCarbs < 0) overColor else MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
             } else {
                 if (!hideCalories) {
                     Text(
@@ -318,21 +351,27 @@ private fun DaySummaryCard(
                     )
                     Spacer(modifier = Modifier.height(4.dp))
                 }
-                Text(
-                    text = "P: ${consumedProtein}g / ${targetProtein}g",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer,
-                )
-                Text(
-                    text = "F: ${consumedFat}g / ${targetFat}g",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer,
-                )
-                Text(
-                    text = "C: ${consumedCarbs}g / ${targetCarbs}g",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer,
-                )
+                if (showProtein) {
+                    Text(
+                        text = "P: ${consumedProtein}g / ${targetProtein}g",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+                if (showFat) {
+                    Text(
+                        text = "F: ${consumedFat}g / ${targetFat}g",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+                if (showCarbs) {
+                    Text(
+                        text = "C: ${consumedCarbs}g / ${targetCarbs}g",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
             }
         }
     }
@@ -343,6 +382,9 @@ private fun MealCard(
     mealWithComponents: MealWithComponents,
     totals: DayNutrientTotals,
     hideCalories: Boolean,
+    showProtein: Boolean,
+    showFat: Boolean,
+    showCarbs: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -393,10 +435,22 @@ private fun MealCard(
                 Spacer(modifier = Modifier.height(4.dp))
 
                 val calorieText =
-                    if (hideCalories) {
-                        "P: ${totals.protein}g F: ${totals.fat}g C: ${totals.carbs}g"
-                    } else {
-                        "${totals.calories} kcal (P:${totals.protein}g F:${totals.fat}g C:${totals.carbs}g)"
+                    buildString {
+                        if (!hideCalories) {
+                            append("${totals.calories} kcal")
+                        }
+                        if (showProtein) {
+                            if (isNotEmpty()) append(" ")
+                            append("P:${totals.protein}g")
+                        }
+                        if (showFat) {
+                            if (isNotEmpty()) append(" ")
+                            append("F:${totals.fat}g")
+                        }
+                        if (showCarbs) {
+                            if (isNotEmpty()) append(" ")
+                            append("C:${totals.carbs}g")
+                        }
                     }
                 Text(
                     text = calorieText,

--- a/app/src/main/java/pro/trousev/mealcontrol/ui/scanmeal/MealEditScreen.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/scanmeal/MealEditScreen.kt
@@ -48,6 +48,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.rememberAsyncImagePainter
 import pro.trousev.mealcontrol.data.local.entity.MealWithComponents
 import pro.trousev.mealcontrol.data.remote.MealComponentDto
+import pro.trousev.mealcontrol.viewmodel.DailyBudgetProvider
+import pro.trousev.mealcontrol.viewmodel.DayNutrientTotals
 import pro.trousev.mealcontrol.viewmodel.MealDetectionMessage
 import pro.trousev.mealcontrol.viewmodel.MealDetectionViewModel
 import java.io.File
@@ -56,6 +58,9 @@ import java.io.File
 fun MealEditScreen(
     photoUri: String,
     existingMeal: MealWithComponents? = null,
+    showProtein: Boolean = true,
+    showFat: Boolean = true,
+    showCarbs: Boolean = true,
     onUpdate: (String, List<Triple<String, Double, List<Number>>>) -> Unit,
     onDelete: () -> Unit,
     onRetake: () -> Unit,
@@ -105,6 +110,9 @@ fun MealEditScreen(
                 currentComponents = state.currentComponents,
                 currentQuestion = state.currentQuestion,
                 mealName = state.mealName,
+                showProtein = showProtein,
+                showFat = showFat,
+                showCarbs = showCarbs,
                 modifier = Modifier.weight(1f),
             )
         }
@@ -216,6 +224,9 @@ private fun ChatContent(
     currentComponents: List<MealComponentDto>?,
     currentQuestion: String?,
     mealName: String?,
+    showProtein: Boolean = true,
+    showFat: Boolean = true,
+    showCarbs: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -254,6 +265,9 @@ private fun ChatContent(
             }
             MealComponentsList(
                 components = currentComponents,
+                showProtein = showProtein,
+                showFat = showFat,
+                showCarbs = showCarbs,
                 modifier = Modifier.padding(vertical = 8.dp),
             )
         }
@@ -318,6 +332,9 @@ private fun ChatMessageItem(
 @Composable
 private fun MealComponentsList(
     components: List<MealComponentDto>,
+    showProtein: Boolean = true,
+    showFat: Boolean = true,
+    showCarbs: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -348,11 +365,26 @@ private fun MealComponentsList(
                 ) {
                     Column(modifier = Modifier.weight(1f)) {
                         Text(text = "${component.weightG.toInt()}g of ${component.name}")
-                        Text(
-                            text = "${component.proteinG.toInt()}g prot, ${component.fatG.toInt()}g fat, ${component.carbsG.toInt()}g carb",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
+                        if (showProtein || showFat || showCarbs) {
+                            Text(
+                                text =
+                                    buildString {
+                                        if (showProtein) {
+                                            append("${component.proteinG.toInt()}g prot")
+                                        }
+                                        if (showFat) {
+                                            if (isNotEmpty()) append(", ")
+                                            append("${component.fatG.toInt()}g fat")
+                                        }
+                                        if (showCarbs) {
+                                            if (isNotEmpty()) append(", ")
+                                            append("${component.carbsG.toInt()}g carb")
+                                        }
+                                    },
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
                     }
                     Column(horizontalAlignment = Alignment.End) {
                         Text(
@@ -384,7 +416,19 @@ private fun MealComponentsList(
                     style = MaterialTheme.typography.titleMedium,
                 )
                 Text(
-                    text = "$totalCalories kcal (P:${totalProtein}g F:${totalFat}g C:${totalCarbs}g)",
+                    text =
+                        buildString {
+                            append("$totalCalories kcal")
+                            if (showProtein) {
+                                append(" P:${totalProtein}g")
+                            }
+                            if (showFat) {
+                                append(" F:${totalFat}g")
+                            }
+                            if (showCarbs) {
+                                append(" C:${totalCarbs}g")
+                            }
+                        },
                     style = MaterialTheme.typography.titleMedium,
                 )
             }

--- a/app/src/main/java/pro/trousev/mealcontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/settings/SettingsScreen.kt
@@ -133,30 +133,27 @@ fun SettingsScreen(
             )
 
             OutlinedTextField(
-                value = if (formState.customProteinGrams > 0) formState.customProteinGrams.toString() else "",
+                value = formState.customProteinGrams.toString(),
                 onValueChange = { viewModel.updateCustomProteinGrams(it.toIntOrNull() ?: 0) },
                 label = { Text("Protein (g)") },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth(),
-                isError = formState.customModeError != null,
             )
 
             OutlinedTextField(
-                value = if (formState.customFatGrams > 0) formState.customFatGrams.toString() else "",
+                value = formState.customFatGrams.toString(),
                 onValueChange = { viewModel.updateCustomFatGrams(it.toIntOrNull() ?: 0) },
                 label = { Text("Fat (g)") },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth(),
-                isError = formState.customModeError != null,
             )
 
             OutlinedTextField(
-                value = if (formState.customCarbGrams > 0) formState.customCarbGrams.toString() else "",
+                value = formState.customCarbGrams.toString(),
                 onValueChange = { viewModel.updateCustomCarbGrams(it.toIntOrNull() ?: 0) },
                 label = { Text("Carbs (g)") },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth(),
-                isError = formState.customModeError != null,
             )
 
             if (formState.customModeError != null) {

--- a/app/src/main/java/pro/trousev/mealcontrol/viewmodel/DailyBudgetProvider.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/viewmodel/DailyBudgetProvider.kt
@@ -28,6 +28,21 @@ object DailyBudgetProvider {
 
     fun shouldHideCalories(settings: UserSettingsEntity): Boolean = settings.hideCaloriesEnabled
 
+    fun shouldShowProtein(
+        customModeEnabled: Boolean,
+        budget: DailyBudget,
+    ): Boolean = !customModeEnabled || budget.protein > 0
+
+    fun shouldShowFat(
+        customModeEnabled: Boolean,
+        budget: DailyBudget,
+    ): Boolean = !customModeEnabled || budget.fat > 0
+
+    fun shouldShowCarbs(
+        customModeEnabled: Boolean,
+        budget: DailyBudget,
+    ): Boolean = !customModeEnabled || budget.carbs > 0
+
     private fun calculateNormalBudget(settings: UserSettingsEntity): DailyBudget {
         val gender =
             try {

--- a/app/src/main/java/pro/trousev/mealcontrol/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/viewmodel/SettingsViewModel.kt
@@ -307,41 +307,25 @@ class SettingsViewModel : ViewModel() {
         val state = _formState.value
         if (state.workingMode != WorkingMode.MANUAL) return
 
-        val hasAtLeastOneMacro = state.customProteinGrams > 0 || state.customFatGrams > 0 || state.customCarbGrams > 0
-        val customModeError =
-            if (!hasAtLeastOneMacro &&
-                state.customProteinGrams == 0 &&
-                state.customFatGrams == 0 &&
-                state.customCarbGrams == 0
-            ) {
-                "At least one macro must be greater than 0"
-            } else {
-                null
-            }
-
-        if (hasAtLeastOneMacro) {
-            val proteinG = state.customProteinGrams
-            val fatG = state.customFatGrams
-            val carbG = state.customCarbGrams
-            val proteinCalories = proteinG * 4
-            val fatCalories = fatG * 9
-            val carbCalories = carbG * 4
-            val calories = proteinCalories + fatCalories + carbCalories
-            val calculation =
-                CalorieCalculation(
-                    bmr = 0,
-                    tdee = 0,
-                    dailyDeficit = 0,
-                    dailyCalories = calories,
-                    proteinGrams = proteinG,
-                    fatGrams = fatG,
-                    carbGrams = carbG,
-                )
-            _formState.value = state.copy(isValid = true, calculation = calculation, customModeError = null)
-            saveTrigger.trySend(Unit)
-        } else {
-            _formState.value = state.copy(isValid = false, calculation = null, customModeError = customModeError)
-        }
+        val proteinG = state.customProteinGrams
+        val fatG = state.customFatGrams
+        val carbG = state.customCarbGrams
+        val proteinCalories = proteinG * 4
+        val fatCalories = fatG * 9
+        val carbCalories = carbG * 4
+        val calories = proteinCalories + fatCalories + carbCalories
+        val calculation =
+            CalorieCalculation(
+                bmr = 0,
+                tdee = 0,
+                dailyDeficit = 0,
+                dailyCalories = calories,
+                proteinGrams = proteinG,
+                fatGrams = fatG,
+                carbGrams = carbG,
+            )
+        _formState.value = state.copy(isValid = true, calculation = calculation, customModeError = null)
+        saveTrigger.trySend(Unit)
     }
 
     private fun recalculate() {


### PR DESCRIPTION
## Summary
- Allow users to set 0 as daily macro target in Manual Mode (previously required at least one macro > 0)
- Hide macros in UI when value is 0 (protein/fat/carbs)
- Clean up SettingsScreen UI by removing validation error states that are no longer needed