### PR TITLE
Add tag-based release workflow and release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [master]
+    tags: ['v*']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -60,8 +60,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: release-${{ github.sha }}
-          name: Release ${{ github.sha }}
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
           generate_release_notes: true
           files: app/build/outputs/apk/prod/release/app-prod-release.apk
         env:

--- a/script/release
+++ b/script/release
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/.."
+
+LATEST_TAG=$(git tag | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -V | tail -1)
+
+if [ -z "$LATEST_TAG" ]; then
+    CURRENT_VERSION="0.0.0"
+else
+    CURRENT_VERSION="$LATEST_TAG"
+fi
+
+MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
+MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
+PATCH=$(echo "$CURRENT_VERSION" | cut -d. -f3)
+
+PATCH=$((PATCH + 1))
+
+NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+
+echo "Current version: $CURRENT_VERSION"
+echo "New version: $NEW_VERSION"
+
+git tag -a "$NEW_VERSION" -m "$NEW_VERSION"
+git push origin "$NEW_VERSION"
+
+echo "Pushed tag: $NEW_VERSION"


### PR DESCRIPTION
## Summary
- Add `./script/release` script that bumps patch version and pushes v* tags
- Update release workflow to trigger on tag push instead of every master commit
- Now releases are created only when a `vX.X.X` tag is pushed, not on every merge to master