### PR TITLE
Cache OpenAiService instance in ChatRepository

### DIFF
--- a/app/src/main/java/pro/trousev/mealcontrol/data/repository/ChatRepository.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/data/repository/ChatRepository.kt
@@ -24,6 +24,17 @@ class ChatRepository(
     private val messageDao: MessageDao,
     private val userSettingsRepository: UserSettingsRepository,
 ) {
+    private var openAiService: OpenAiService? = null
+    private var cachedApiKey: String? = null
+
+    private fun getOpenAiService(apiKey: String): OpenAiService {
+        if (openAiService == null || cachedApiKey != apiKey) {
+            cachedApiKey = apiKey
+            openAiService = OpenAiService(apiKey)
+        }
+        return openAiService!!
+    }
+
     suspend fun getAllConversations(): List<ConversationWithLastMessage> {
         val conversations = conversationDao.getChatConversations()
         return conversations.map { conversation ->
@@ -93,8 +104,8 @@ class ChatRepository(
 
         return withContext(Dispatchers.IO) {
             try {
-                val openAiService = OpenAiService(apiKey)
-                val result = openAiService.chat(truncatedMessages)
+                val service = getOpenAiService(apiKey)
+                val result = service.chat(truncatedMessages)
 
                 when {
                     result.isSuccess -> {


### PR DESCRIPTION
## Summary
- Cache `OpenAiService` instance in `ChatRepository` to avoid creating a new HTTP client for every message sent
- Service is only recreated when the API key changes

fixes: #32