### PR TITLE
Fix working mode radio UX to match gender radio pattern

### DIFF
--- a/app/src/main/java/pro/trousev/mealcontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/settings/SettingsScreen.kt
@@ -64,42 +64,32 @@ fun SettingsScreen(
         )
 
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .selectableGroup(),
             horizontalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            val autoModifier =
-                Modifier
-                    .selectableGroup()
-                    .weight(1f)
-            Row(
-                modifier = autoModifier,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                RadioButton(
-                    selected = formState.workingMode == WorkingMode.AUTOMATIC,
-                    onClick = { viewModel.updateWorkingMode(WorkingMode.AUTOMATIC) },
-                )
-                Text(
-                    text = "Automatic",
-                    modifier = Modifier.padding(start = 8.dp),
-                )
-            }
-            val manualModifier =
-                Modifier
-                    .selectableGroup()
-                    .weight(1f)
-            Row(
-                modifier = manualModifier,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                RadioButton(
-                    selected = formState.workingMode == WorkingMode.MANUAL,
-                    onClick = { viewModel.updateWorkingMode(WorkingMode.MANUAL) },
-                )
-                Text(
-                    text = "Manual",
-                    modifier = Modifier.padding(start = 8.dp),
-                )
+            WorkingMode.entries.forEach { mode ->
+                Row(
+                    modifier =
+                        Modifier
+                            .selectable(
+                                selected = formState.workingMode == mode,
+                                onClick = { viewModel.updateWorkingMode(mode) },
+                                role = Role.RadioButton,
+                            ),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    RadioButton(
+                        selected = formState.workingMode == mode,
+                        onClick = null,
+                    )
+                    Text(
+                        text = mode.name.lowercase().replaceFirstChar { it.uppercase() },
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Refactored the Working Mode radio buttons to follow the same UX pattern as the Gender radio selection
- Entire row is now clickable (via `Modifier.selectable`), not just the radio button itself
- Uses `selectableGroup()` on the parent Row and `forEach` iteration over `WorkingMode.entries` instead of duplicated rows with `selectableGroup()` and `weight(1f)`
- `RadioButton` now delegates click handling to the row (`onClick = null`)

## Before
- Only the radio button circle was clickable
- Each inner Row had its own `selectableGroup()` modifier (semantically incorrect)
- Duplicated Row code for each option

## After
- Clicking anywhere on the label selects the radio (matches Gender radio behavior)
- `selectableGroup()` on outer Row, `selectable()` on inner rows (correct semantics)
- Single `forEach` loop like Gender radio