### PR TITLE
Add 'Hide budget exceeds' setting

### DIFF
--- a/app/src/main/java/pro/trousev/mealcontrol/data/local/MealControlDatabase.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/data/local/MealControlDatabase.kt
@@ -24,7 +24,7 @@ import pro.trousev.mealcontrol.data.local.entity.UserSettingsEntity
         MessageEntity::class,
         UserSettingsEntity::class,
     ],
-    version = 7,
+    version = 8,
     exportSchema = false,
 )
 abstract class MealControlDatabase : RoomDatabase() {
@@ -109,6 +109,15 @@ abstract class MealControlDatabase : RoomDatabase() {
                 }
             }
 
+        private val MIGRATION_7_8 =
+            object : Migration(7, 8) {
+                override fun migrate(database: SupportSQLiteDatabase) {
+                    database.execSQL(
+                        "ALTER TABLE user_settings ADD COLUMN hideBudgetExceededEnabled INTEGER NOT NULL DEFAULT 0",
+                    )
+                }
+            }
+
         fun getDatabase(context: Context): MealControlDatabase =
             instance ?: synchronized(this) {
                 val dbInstance =
@@ -123,6 +132,7 @@ abstract class MealControlDatabase : RoomDatabase() {
                             MIGRATION_4_5,
                             MIGRATION_5_6,
                             MIGRATION_6_7,
+                            MIGRATION_7_8,
                         ).build()
                 instance = dbInstance
                 dbInstance

--- a/app/src/main/java/pro/trousev/mealcontrol/data/local/entity/UserSettingsEntity.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/data/local/entity/UserSettingsEntity.kt
@@ -20,6 +20,7 @@ data class UserSettingsEntity(
     val openAiApiKey: String = "",
     val customModeEnabled: Boolean = false,
     val hideCaloriesEnabled: Boolean = false,
+    val hideBudgetExceededEnabled: Boolean = false,
     val customProteinGrams: Int = 0,
     val customFatGrams: Int = 0,
     val customCarbGrams: Int = 0,

--- a/app/src/main/java/pro/trousev/mealcontrol/ui/meals/MealsScreen.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/meals/MealsScreen.kt
@@ -77,6 +77,7 @@ fun MealsScreen(
     val targetFat = settingsFormState.calculation?.fatGrams ?: 0
     val targetCarbs = settingsFormState.calculation?.carbGrams ?: 0
     val hideCalories = settingsFormState.hideCaloriesEnabled
+    val hideBudgetExceeded = settingsFormState.hideBudgetExceededEnabled
     val isManualMode = settingsFormState.workingMode == WorkingMode.MANUAL
     val budget =
         DailyBudget(
@@ -122,6 +123,7 @@ fun MealsScreen(
                 targetFat = targetFat,
                 targetCarbs = targetCarbs,
                 hideCalories = hideCalories,
+                hideBudgetExceeded = hideBudgetExceeded,
                 isManualMode = isManualMode,
                 budget = budget,
                 onAddMealClick = onAddMealClick,
@@ -151,6 +153,7 @@ private fun DayPage(
     targetFat: Int,
     targetCarbs: Int,
     hideCalories: Boolean,
+    hideBudgetExceeded: Boolean,
     isManualMode: Boolean,
     budget: DailyBudget,
     onAddMealClick: () -> Unit,
@@ -192,6 +195,7 @@ private fun DayPage(
                     targetCarbs = targetCarbs,
                     remainingCarbs = remainingCarbs,
                     hideCalories = hideCalories,
+                    hideBudgetExceeded = hideBudgetExceeded,
                     showProtein = showProtein,
                     showFat = showFat,
                     showCarbs = showCarbs,
@@ -283,6 +287,7 @@ private fun DaySummaryCard(
     targetCarbs: Int,
     remainingCarbs: Int,
     hideCalories: Boolean,
+    hideBudgetExceeded: Boolean,
     showProtein: Boolean,
     showFat: Boolean,
     showCarbs: Boolean,
@@ -314,32 +319,68 @@ private fun DaySummaryCard(
 
             if (isToday) {
                 if (!hideCalories) {
+                    val caloriesText =
+                        if (remainingCalories >= 0) {
+                            "$remainingCalories / $targetCalories kcal left"
+                        } else if (hideBudgetExceeded) {
+                            "$consumedCalories kcal already consumed"
+                        } else {
+                            "${-remainingCalories} / $targetCalories kcal over"
+                        }
+                    val caloriesColor = if (remainingCalories < 0 && !hideBudgetExceeded) overColor else MaterialTheme.colorScheme.onPrimaryContainer
                     Text(
-                        text = if (remainingCalories >= 0) "$remainingCalories / $targetCalories kcal left" else "${-remainingCalories} / $targetCalories kcal over",
+                        text = caloriesText,
                         style = MaterialTheme.typography.headlineSmall,
-                        color = if (remainingCalories < 0) overColor else MaterialTheme.colorScheme.onPrimaryContainer,
+                        color = caloriesColor,
                     )
                     Spacer(modifier = Modifier.height(4.dp))
                 }
                 if (showProtein) {
+                    val proteinText =
+                        if (remainingProtein >= 0) {
+                            "$remainingProtein / ${targetProtein}g protein left"
+                        } else if (hideBudgetExceeded) {
+                            "${consumedProtein}g of protein already consumed"
+                        } else {
+                            "${-remainingProtein} / ${targetProtein}g protein over"
+                        }
+                    val proteinColor = if (remainingProtein < 0 && !hideBudgetExceeded) overColor else MaterialTheme.colorScheme.onPrimaryContainer
                     Text(
-                        text = if (remainingProtein >= 0) "$remainingProtein / ${targetProtein}g protein left" else "${-remainingProtein} / ${targetProtein}g protein over",
+                        text = proteinText,
                         style = MaterialTheme.typography.bodyMedium,
-                        color = if (remainingProtein < 0) overColor else MaterialTheme.colorScheme.onPrimaryContainer,
+                        color = proteinColor,
                     )
                 }
                 if (showFat) {
+                    val fatText =
+                        if (remainingFat >= 0) {
+                            "$remainingFat / ${targetFat}g fat left"
+                        } else if (hideBudgetExceeded) {
+                            "${consumedFat}g of fat already consumed"
+                        } else {
+                            "${-remainingFat} / ${targetFat}g fat over"
+                        }
+                    val fatColor = if (remainingFat < 0 && !hideBudgetExceeded) overColor else MaterialTheme.colorScheme.onPrimaryContainer
                     Text(
-                        text = if (remainingFat >= 0) "$remainingFat / ${targetFat}g fat left" else "${-remainingFat} / ${targetFat}g fat over",
+                        text = fatText,
                         style = MaterialTheme.typography.bodyMedium,
-                        color = if (remainingFat < 0) overColor else MaterialTheme.colorScheme.onPrimaryContainer,
+                        color = fatColor,
                     )
                 }
                 if (showCarbs) {
+                    val carbsText =
+                        if (remainingCarbs >= 0) {
+                            "$remainingCarbs / ${targetCarbs}g carbs left"
+                        } else if (hideBudgetExceeded) {
+                            "${consumedCarbs}g of carbs already consumed"
+                        } else {
+                            "${-remainingCarbs} / ${targetCarbs}g carbs over"
+                        }
+                    val carbsColor = if (remainingCarbs < 0 && !hideBudgetExceeded) overColor else MaterialTheme.colorScheme.onPrimaryContainer
                     Text(
-                        text = if (remainingCarbs >= 0) "$remainingCarbs / ${targetCarbs}g carbs left" else "${-remainingCarbs} / ${targetCarbs}g carbs over",
+                        text = carbsText,
                         style = MaterialTheme.typography.bodyMedium,
-                        color = if (remainingCarbs < 0) overColor else MaterialTheme.colorScheme.onPrimaryContainer,
+                        color = carbsColor,
                     )
                 }
             } else {

--- a/app/src/main/java/pro/trousev/mealcontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/settings/SettingsScreen.kt
@@ -126,6 +126,29 @@ fun SettingsScreen(
             )
         }
 
+        val hideBudgetExceededModifier =
+            Modifier
+                .fillMaxWidth()
+                .selectable(
+                    selected = formState.hideBudgetExceededEnabled,
+                    onClick = { viewModel.updateHideBudgetExceeded(!formState.hideBudgetExceededEnabled) },
+                    role = Role.Checkbox,
+                )
+        Row(
+            modifier = hideBudgetExceededModifier,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Checkbox(
+                checked = formState.hideBudgetExceededEnabled,
+                onCheckedChange = null,
+            )
+            Text(
+                text = "Hide budget exceeds",
+                modifier = Modifier.padding(start = 8.dp),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+
         if (formState.workingMode == WorkingMode.MANUAL) {
             Text(
                 text = "Daily Macro Targets",

--- a/app/src/main/java/pro/trousev/mealcontrol/viewmodel/DailyBudgetProvider.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/viewmodel/DailyBudgetProvider.kt
@@ -28,6 +28,8 @@ object DailyBudgetProvider {
 
     fun shouldHideCalories(settings: UserSettingsEntity): Boolean = settings.hideCaloriesEnabled
 
+    fun shouldHideBudgetExceeded(settings: UserSettingsEntity): Boolean = settings.hideBudgetExceededEnabled
+
     fun shouldShowProtein(
         customModeEnabled: Boolean,
         budget: DailyBudget,

--- a/app/src/main/java/pro/trousev/mealcontrol/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/viewmodel/SettingsViewModel.kt
@@ -69,6 +69,7 @@ data class SettingsFormState(
     val openAiApiKey: String = "",
     val workingMode: WorkingMode = WorkingMode.AUTOMATIC,
     val hideCaloriesEnabled: Boolean = false,
+    val hideBudgetExceededEnabled: Boolean = false,
     val customProteinGrams: Int = 0,
     val customFatGrams: Int = 0,
     val customCarbGrams: Int = 0,
@@ -161,6 +162,7 @@ class SettingsViewModel : ViewModel() {
                         openAiApiKey = settings.openAiApiKey,
                         workingMode = workingMode,
                         hideCaloriesEnabled = settings.hideCaloriesEnabled,
+                        hideBudgetExceededEnabled = settings.hideBudgetExceededEnabled,
                         customProteinGrams = settings.customProteinGrams,
                         customFatGrams = settings.customFatGrams,
                         customCarbGrams = settings.customCarbGrams,
@@ -276,6 +278,11 @@ class SettingsViewModel : ViewModel() {
         saveTrigger.trySend(Unit)
     }
 
+    fun updateHideBudgetExceeded(enabled: Boolean) {
+        _formState.value = _formState.value.copy(hideBudgetExceededEnabled = enabled)
+        saveTrigger.trySend(Unit)
+    }
+
     fun updateCustomProteinGrams(grams: Int) {
         _formState.value =
             _formState.value.copy(
@@ -386,6 +393,7 @@ class SettingsViewModel : ViewModel() {
                 openAiApiKey = state.openAiApiKey,
                 customModeEnabled = isManualMode,
                 hideCaloriesEnabled = state.hideCaloriesEnabled,
+                hideBudgetExceededEnabled = state.hideBudgetExceededEnabled,
                 customProteinGrams = state.customProteinGrams,
                 customFatGrams = state.customFatGrams,
                 customCarbGrams = state.customCarbGrams,

--- a/app/src/test/java/pro/trousev/mealcontrol/viewmodel/DailyBudgetProviderTest.kt
+++ b/app/src/test/java/pro/trousev/mealcontrol/viewmodel/DailyBudgetProviderTest.kt
@@ -131,6 +131,24 @@ class DailyBudgetProviderTest {
     }
 
     @Test
+    fun shouldHideBudgetExceeded_returnsFalseWhenDisabled() {
+        val settings = UserSettingsEntity(hideBudgetExceededEnabled = false)
+
+        val result = DailyBudgetProvider.shouldHideBudgetExceeded(settings)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun shouldHideBudgetExceeded_returnsTrueWhenEnabled() {
+        val settings = UserSettingsEntity(hideBudgetExceededEnabled = true)
+
+        val result = DailyBudgetProvider.shouldHideBudgetExceeded(settings)
+
+        assertTrue(result)
+    }
+
+    @Test
     fun calculateBudget_customMode_doesNotUseBodyMeasurements() {
         val settings =
             UserSettingsEntity(


### PR DESCRIPTION
## Summary
- Adds a "Hide budget exceeds" checkbox in Settings (below "Hide calories display") for users who prefer not to see red "over budget" warnings
- When enabled and a nutrient/calories exceed the daily budget, displays neutral text like "50g of protein already consumed" instead of "5 / 50g protein over", with normal color (no red)
- When under budget, behavior is unchanged ("X left" text as before)
- Includes DB migration (v7→v8), full ViewModel wiring, and unit tests