### PR TITLE
Fix memory leak in image compression

### DIFF
--- a/app/src/main/java/pro/trousev/mealcontrol/util/ImageCompression.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/util/ImageCompression.kt
@@ -33,9 +33,7 @@ object ImageCompression {
         bitmap = rotateImageIfRequired(bitmap, filePath)
 
         val scaledBitmap = scaleBitmap(bitmap, MAX_DIMENSION)
-        if (scaledBitmap != bitmap) {
-            bitmap.recycle()
-        }
+        bitmap.recycle()
 
         val outputStream = ByteArrayOutputStream()
         scaledBitmap.compress(Bitmap.CompressFormat.JPEG, COMPRESSION_QUALITY, outputStream)
@@ -71,15 +69,15 @@ object ImageCompression {
         val width = bitmap.width
         val height = bitmap.height
 
-        if (width <= maxDimension && height <= maxDimension) {
-            return bitmap
-        }
-
         val scale =
-            if (width > height) {
-                maxDimension.toFloat() / width
+            if (width > maxDimension || height > maxDimension) {
+                if (width > height) {
+                    maxDimension.toFloat() / width
+                } else {
+                    maxDimension.toFloat() / height
+                }
             } else {
-                maxDimension.toFloat() / height
+                1f
             }
 
         val newWidth = (width * scale).toInt()

--- a/app/src/test/java/pro/trousev/mealcontrol/util/ImageCompressionTest.kt
+++ b/app/src/test/java/pro/trousev/mealcontrol/util/ImageCompressionTest.kt
@@ -1,0 +1,75 @@
+package pro.trousev.mealcontrol.util
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.io.File
+import java.io.FileOutputStream
+
+@RunWith(RobolectricTestRunner::class)
+class ImageCompressionTest {
+    private val context = RuntimeEnvironment.getApplication()
+
+    @Test
+    fun compressImage_smallImageWithinBounds_returnsCompressedData() {
+        val file = createTempImageFile(width = 100, height = 100, color = Color.RED)
+
+        val result = ImageCompression.compressImage(file.absolutePath)
+
+        assertNotNull(result)
+        assertTrue(result.isNotEmpty())
+    }
+
+    @Test
+    fun compressImage_largeImageExceedingBounds_returnsCompressedData() {
+        val file = createTempImageFile(width = 2048, height = 2048, color = Color.BLUE)
+
+        val result = ImageCompression.compressImage(file.absolutePath)
+
+        assertNotNull(result)
+        assertTrue(result.isNotEmpty())
+    }
+
+    @Test
+    fun compressImage_wideImage_returnsCompressedData() {
+        val file = createTempImageFile(width = 3000, height = 500, color = Color.GREEN)
+
+        val result = ImageCompression.compressImage(file.absolutePath)
+
+        assertNotNull(result)
+        assertTrue(result.isNotEmpty())
+    }
+
+    @Test
+    fun compressImage_tallImage_returnsCompressedData() {
+        val file = createTempImageFile(width = 500, height = 3000, color = Color.YELLOW)
+
+        val result = ImageCompression.compressImage(file.absolutePath)
+
+        assertNotNull(result)
+        assertTrue(result.isNotEmpty())
+    }
+
+    @Test(expected = java.io.FileNotFoundException::class)
+    fun compressImage_nonExistingFile_throwsException() {
+        ImageCompression.compressImage("/non/existing/path/image.jpg")
+    }
+
+    private fun createTempImageFile(width: Int, height: Int, color: Int): File {
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        bitmap.eraseColor(color)
+
+        val file = File(context.cacheDir, "test_image_${width}x${height}.jpg")
+        FileOutputStream(file).use { out ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, out)
+        }
+        bitmap.recycle()
+        return file
+    }
+}

--- a/app/src/test/java/pro/trousev/mealcontrol/util/ImageCompressionTest.kt
+++ b/app/src/test/java/pro/trousev/mealcontrol/util/ImageCompressionTest.kt
@@ -61,11 +61,15 @@ class ImageCompressionTest {
         ImageCompression.compressImage("/non/existing/path/image.jpg")
     }
 
-    private fun createTempImageFile(width: Int, height: Int, color: Int): File {
+    private fun createTempImageFile(
+        width: Int,
+        height: Int,
+        color: Int,
+    ): File {
         val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
         bitmap.eraseColor(color)
 
-        val file = File(context.cacheDir, "test_image_${width}x${height}.jpg")
+        val file = File(context.cacheDir, "test_image_${width}x$height.jpg")
         FileOutputStream(file).use { out ->
             bitmap.compress(Bitmap.CompressFormat.JPEG, 100, out)
         }


### PR DESCRIPTION
## Summary

Fixes a memory leak in  where the original bitmap was not being recycled when image dimensions were already within bounds.

## Changes

- **Fixed memory leak**: The original bitmap is now always recycled after creating the scaled version, instead of only recycling when .
- **Refactored **: Always returns a new  via , even when no scaling is needed (scale factor = 1.0). This ensures the original bitmap can safely be recycled in all cases.
- **Added unit tests**: New  with coverage for:
  - Small images within bounds
  - Large images exceeding bounds
  - Wide and tall images
  - Non-existing file error handling