### PR TITLE
Replace input sanitization with validation - never modify user input

### DIFF
--- a/app/src/main/java/pro/trousev/mealcontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/ui/settings/SettingsScreen.kt
@@ -151,6 +151,7 @@ fun SettingsScreen(
                 label = { Text("Protein (g)") },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth(),
+                isError = formState.customModeError != null,
             )
 
             OutlinedTextField(
@@ -159,6 +160,7 @@ fun SettingsScreen(
                 label = { Text("Fat (g)") },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth(),
+                isError = formState.customModeError != null,
             )
 
             OutlinedTextField(
@@ -167,6 +169,7 @@ fun SettingsScreen(
                 label = { Text("Carbs (g)") },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth(),
+                isError = formState.customModeError != null,
             )
 
             if (formState.customModeError != null) {
@@ -190,8 +193,8 @@ fun SettingsScreen(
                 label = { Text("Weight (kg)") },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                 modifier = Modifier.fillMaxWidth(),
-                supportingText = { Text("30-300 kg") },
-                isError = formState.weightKg.isNotEmpty() && (formState.weightKg.toFloatOrNull()?.let { it < 30 || it > 300 } ?: true),
+                supportingText = { Text(formState.weightError ?: "30-300 kg") },
+                isError = formState.weightError != null,
             )
 
             OutlinedTextField(
@@ -200,8 +203,8 @@ fun SettingsScreen(
                 label = { Text("Height (cm)") },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                 modifier = Modifier.fillMaxWidth(),
-                supportingText = { Text("100-250 cm") },
-                isError = formState.heightCm.isNotEmpty() && (formState.heightCm.toFloatOrNull()?.let { it < 100 || it > 250 } ?: true),
+                supportingText = { Text(formState.heightError ?: "100-250 cm") },
+                isError = formState.heightError != null,
             )
 
             OutlinedTextField(
@@ -210,8 +213,8 @@ fun SettingsScreen(
                 label = { Text("Age (years)") },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth(),
-                supportingText = { Text("10-120 years") },
-                isError = formState.age.isNotEmpty() && (formState.age.toIntOrNull()?.let { it < 10 || it > 120 } ?: true),
+                supportingText = { Text(formState.ageError ?: "10-120 years") },
+                isError = formState.ageError != null,
             )
 
             Text(
@@ -262,10 +265,8 @@ fun SettingsScreen(
                 label = { Text("Weight change per week (kg)") },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                 modifier = Modifier.fillMaxWidth(),
-                supportingText = { Text("Negative to lose, positive to gain. Range: -5 to +5") },
-                isError =
-                    formState.targetWeightChangeKg.isNotEmpty() &&
-                        (formState.targetWeightChangeKg.toFloatOrNull()?.let { it < -5 || it > 5 } ?: true),
+                supportingText = { Text(formState.targetWeightChangeError ?: "Negative to lose, positive to gain. Range: -5 to +5") },
+                isError = formState.targetWeightChangeError != null,
             )
 
             Text(

--- a/app/src/main/java/pro/trousev/mealcontrol/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/viewmodel/SettingsViewModel.kt
@@ -77,6 +77,10 @@ data class SettingsFormState(
     val calculation: CalorieCalculation? = null,
     val customDistributionError: String? = null,
     val customModeError: String? = null,
+    val weightError: String? = null,
+    val heightError: String? = null,
+    val ageError: String? = null,
+    val targetWeightChangeError: String? = null,
 )
 
 class SettingsViewModel : ViewModel() {
@@ -175,20 +179,17 @@ class SettingsViewModel : ViewModel() {
     }
 
     fun updateWeight(weight: String) {
-        val filtered = weight.filter { it.isDigit() || it == '.' }
-        _formState.value = _formState.value.copy(weightKg = filtered)
+        _formState.value = _formState.value.copy(weightKg = weight)
         recalculate()
     }
 
     fun updateHeight(height: String) {
-        val filtered = height.filter { it.isDigit() || it == '.' }
-        _formState.value = _formState.value.copy(heightCm = filtered)
+        _formState.value = _formState.value.copy(heightCm = height)
         recalculate()
     }
 
     fun updateAge(age: String) {
-        val filtered = age.filter { it.isDigit() }
-        _formState.value = _formState.value.copy(age = filtered)
+        _formState.value = _formState.value.copy(age = age)
         recalculate()
     }
 
@@ -198,13 +199,12 @@ class SettingsViewModel : ViewModel() {
     }
 
     fun updateTargetWeightChange(change: String) {
-        val filtered = change.filter { it.isDigit() || it == '.' || it == '-' }
-        _formState.value = _formState.value.copy(targetWeightChangeKg = filtered)
+        _formState.value = _formState.value.copy(targetWeightChangeKg = change)
 
-        val targetChange = filtered.toFloatOrNull() ?: 0f
+        val targetChange = change.toFloatOrNull()
         val currentDistribution = _formState.value.calorieDistribution
         val newDistribution =
-            if (currentDistribution != CalorieDistribution.CUSTOM) {
+            if (currentDistribution != CalorieDistribution.CUSTOM && targetChange != null) {
                 if (targetChange < 0) CalorieDistribution.HIGH_PROTEIN else CalorieDistribution.BALANCED
             } else {
                 currentDistribution
@@ -225,17 +225,17 @@ class SettingsViewModel : ViewModel() {
     }
 
     fun updateCustomProtein(percent: Int) {
-        _formState.value = _formState.value.copy(customProteinPercent = percent.coerceIn(0, 100))
+        _formState.value = _formState.value.copy(customProteinPercent = percent)
         recalculate()
     }
 
     fun updateCustomFat(percent: Int) {
-        _formState.value = _formState.value.copy(customFatPercent = percent.coerceIn(0, 100))
+        _formState.value = _formState.value.copy(customFatPercent = percent)
         recalculate()
     }
 
     fun updateCustomCarb(percent: Int) {
-        _formState.value = _formState.value.copy(customCarbPercent = percent.coerceIn(0, 100))
+        _formState.value = _formState.value.copy(customCarbPercent = percent)
         recalculate()
     }
 
@@ -286,7 +286,7 @@ class SettingsViewModel : ViewModel() {
     fun updateCustomProteinGrams(grams: Int) {
         _formState.value =
             _formState.value.copy(
-                customProteinGrams = grams.coerceIn(0, 1000),
+                customProteinGrams = grams,
                 customModeError = null,
             )
         recalculateManualMode()
@@ -295,7 +295,7 @@ class SettingsViewModel : ViewModel() {
     fun updateCustomFatGrams(grams: Int) {
         _formState.value =
             _formState.value.copy(
-                customFatGrams = grams.coerceIn(0, 1000),
+                customFatGrams = grams,
                 customModeError = null,
             )
         recalculateManualMode()
@@ -304,7 +304,7 @@ class SettingsViewModel : ViewModel() {
     fun updateCustomCarbGrams(grams: Int) {
         _formState.value =
             _formState.value.copy(
-                customCarbGrams = grams.coerceIn(0, 1000),
+                customCarbGrams = grams,
                 customModeError = null,
             )
         recalculateManualMode()
@@ -317,6 +317,17 @@ class SettingsViewModel : ViewModel() {
         val proteinG = state.customProteinGrams
         val fatG = state.customFatGrams
         val carbG = state.customCarbGrams
+
+        if (proteinG < 0 || fatG < 0 || carbG < 0) {
+            _formState.value =
+                state.copy(
+                    isValid = false,
+                    calculation = null,
+                    customModeError = "Values cannot be negative",
+                )
+            return
+        }
+
         val proteinCalories = proteinG * 4
         val fatCalories = fatG * 9
         val carbCalories = carbG * 4
@@ -337,54 +348,125 @@ class SettingsViewModel : ViewModel() {
 
     private fun recalculate() {
         val state = _formState.value
-        val weight = state.weightKg.toFloatOrNull() ?: 0f
-        val height = state.heightCm.toFloatOrNull() ?: 0f
-        val age = state.age.toIntOrNull() ?: 0
-        val targetChange = state.targetWeightChangeKg.toFloatOrNull() ?: 0f
 
-        val customSum = state.customProteinPercent + state.customFatPercent + state.customCarbPercent
-        val customError =
-            if (state.calorieDistribution == CalorieDistribution.CUSTOM && customSum != 100) {
-                "Must equal 100% (currently $customSum%)"
+        val weight = state.weightKg.toFloatOrNull()
+        val height = state.heightCm.toFloatOrNull()
+        val age = state.age.toIntOrNull()
+        val targetChange = state.targetWeightChangeKg.toFloatOrNull()
+
+        val weightError =
+            when {
+                state.weightKg.isEmpty() -> null
+                weight == null -> "Must be a valid number"
+                weight < 30f -> "Must be at least 30 kg"
+                weight > 300f -> "Must be at most 300 kg"
+                else -> null
+            }
+
+        val heightError =
+            when {
+                state.heightCm.isEmpty() -> null
+                height == null -> "Must be a valid number"
+                height < 100f -> "Must be at least 100 cm"
+                height > 250f -> "Must be at most 250 cm"
+                else -> null
+            }
+
+        val ageError =
+            when {
+                state.age.isEmpty() -> null
+                age == null -> "Must be a valid number"
+                age < 10 -> "Must be at least 10 years"
+                age > 120 -> "Must be at most 120 years"
+                else -> null
+            }
+
+        val targetWeightChangeError =
+            when {
+                state.targetWeightChangeKg.isEmpty() -> null
+                targetChange == null -> "Must be a valid number"
+                targetChange < -5f -> "Must be at least -5 kg"
+                targetChange > 5f -> "Must be at most 5 kg"
+                else -> null
+            }
+
+        val proteinPercent = state.customProteinPercent
+        val fatPercent = state.customFatPercent
+        val carbPercent = state.customCarbPercent
+
+        val customPercentError =
+            if (state.calorieDistribution == CalorieDistribution.CUSTOM) {
+                when {
+                    proteinPercent < 0 || fatPercent < 0 || carbPercent < 0 -> "Values cannot be negative"
+                    proteinPercent > 100 || fatPercent > 100 || carbPercent > 100 -> "Values cannot exceed 100"
+                    proteinPercent + fatPercent + carbPercent != 100 -> "Must equal 100% (currently ${proteinPercent + fatPercent + carbPercent}%)"
+                    else -> null
+                }
             } else {
                 null
             }
 
-        val isValid = weight in 30f..300f && height in 100f..250f && age in 10..120 && customError == null
+        val hasFieldErrors = weightError != null || heightError != null || ageError != null || targetWeightChangeError != null || customPercentError != null
+        val hasRequiredValues = weight != null && height != null && age != null
 
-        if (isValid) {
+        if (!hasFieldErrors && hasRequiredValues) {
             val calculation =
                 calculateCalories(
                     weightKg = weight,
                     heightCm = height,
                     age = age,
                     gender = state.gender,
-                    targetWeightChangeKg = targetChange,
+                    targetWeightChangeKg = targetChange ?: 0f,
                     activityLevel = state.activityLevel,
                     distribution = state.calorieDistribution,
-                    customProtein = state.customProteinPercent,
-                    customFat = state.customFatPercent,
-                    customCarb = state.customCarbPercent,
+                    customProtein = proteinPercent,
+                    customFat = fatPercent,
+                    customCarb = carbPercent,
                 )
-            _formState.value = state.copy(isValid = true, calculation = calculation, customDistributionError = null)
+            _formState.value =
+                state.copy(
+                    isValid = true,
+                    calculation = calculation,
+                    customDistributionError = null,
+                    weightError = null,
+                    heightError = null,
+                    ageError = null,
+                    targetWeightChangeError = null,
+                )
             saveTrigger.trySend(Unit)
         } else {
-            _formState.value = state.copy(isValid = false, calculation = null, customDistributionError = customError)
+            _formState.value =
+                state.copy(
+                    isValid = false,
+                    calculation = null,
+                    customDistributionError = customPercentError,
+                    weightError = weightError,
+                    heightError = heightError,
+                    ageError = ageError,
+                    targetWeightChangeError = targetWeightChangeError,
+                )
         }
     }
 
     private suspend fun performSave() {
         val state = _formState.value
+        if (!state.isValid) return
+
         val isManualMode = state.workingMode == WorkingMode.MANUAL
+
+        val weight = state.weightKg.toFloatOrNull() ?: return
+        val height = state.heightCm.toFloatOrNull() ?: return
+        val age = state.age.toIntOrNull() ?: return
+        val targetChange = state.targetWeightChangeKg.toFloatOrNull() ?: return
 
         val settings =
             UserSettingsEntity(
                 id = 1,
-                weightKg = state.weightKg.toFloatOrNull() ?: 0f,
-                heightCm = state.heightCm.toFloatOrNull() ?: 0f,
-                age = state.age.toIntOrNull() ?: 0,
+                weightKg = weight,
+                heightCm = height,
+                age = age,
                 gender = state.gender.name,
-                targetWeightChangeKg = state.targetWeightChangeKg.toFloatOrNull() ?: 0f,
+                targetWeightChangeKg = targetChange,
                 activityLevel = state.activityLevel.ordinal + 1,
                 calorieDistribution = state.calorieDistribution.name,
                 customProteinPercent = state.customProteinPercent,

--- a/app/src/test/java/pro/trousev/mealcontrol/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/pro/trousev/mealcontrol/viewmodel/SettingsViewModelTest.kt
@@ -65,10 +65,10 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun settingsViewModel_updateWeight_filtersNonNumeric() {
+    fun settingsViewModel_updateWeight_acceptsAnyInput() {
         val viewModel = SettingsViewModel()
         viewModel.updateWeight("80.5kg")
-        assertEquals("80.5", viewModel.formState.value.weightKg)
+        assertEquals("80.5kg", viewModel.formState.value.weightKg)
     }
 
     @Test
@@ -79,17 +79,17 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun settingsViewModel_updateHeight_filtersNonNumeric() {
+    fun settingsViewModel_updateHeight_acceptsAnyInput() {
         val viewModel = SettingsViewModel()
         viewModel.updateHeight("180.5cm")
-        assertEquals("180.5", viewModel.formState.value.heightCm)
+        assertEquals("180.5cm", viewModel.formState.value.heightCm)
     }
 
     @Test
-    fun settingsViewModel_updateAge_filtersNonNumeric() {
+    fun settingsViewModel_updateAge_acceptsAnyInput() {
         val viewModel = SettingsViewModel()
         viewModel.updateAge("30years")
-        assertEquals("30", viewModel.formState.value.age)
+        assertEquals("30years", viewModel.formState.value.age)
     }
 
     @Test
@@ -301,5 +301,79 @@ class SettingsViewModelTest {
         assertTrue(calc.fatGrams > 0)
         assertTrue(calc.carbGrams > 0)
         assertTrue(calc.dailyCalories > 0)
+    }
+
+    @Test
+    fun settingsViewModel_invalidInput_showsErrorButPreservesValue() {
+        val viewModel = SettingsViewModel()
+        viewModel.updateWeight("500")
+        viewModel.updateHeight("180")
+        viewModel.updateAge("30")
+
+        val state = viewModel.formState.value
+        assertEquals("500", state.weightKg)
+        assertNotNull(state.weightError)
+        assertFalse(state.isValid)
+    }
+
+    @Test
+    fun settingsViewModel_customPercent_over100_showsErrorButPreservesValue() {
+        val viewModel = SettingsViewModel()
+        viewModel.updateWeight("80")
+        viewModel.updateHeight("180")
+        viewModel.updateAge("30")
+        viewModel.updateCalorieDistribution(CalorieDistribution.CUSTOM)
+        viewModel.updateCustomProtein(200)
+        viewModel.updateCustomFat(25)
+        viewModel.updateCustomCarb(25)
+
+        val state = viewModel.formState.value
+        assertEquals(200, state.customProteinPercent)
+        assertNotNull(state.customDistributionError)
+        assertFalse(state.isValid)
+    }
+
+    @Test
+    fun settingsViewModel_customPercent_doesNotSumTo100_showsError() {
+        val viewModel = SettingsViewModel()
+        viewModel.updateWeight("80")
+        viewModel.updateHeight("180")
+        viewModel.updateAge("30")
+        viewModel.updateCalorieDistribution(CalorieDistribution.CUSTOM)
+        viewModel.updateCustomProtein(50)
+        viewModel.updateCustomFat(50)
+        viewModel.updateCustomCarb(50)
+
+        val state = viewModel.formState.value
+        assertNotNull(state.customDistributionError)
+        assertFalse(state.isValid)
+    }
+
+    @Test
+    fun settingsViewModel_manualMode_negativeGrams_showsError() {
+        val viewModel = SettingsViewModel()
+        viewModel.updateWorkingMode(WorkingMode.MANUAL)
+        viewModel.updateCustomProteinGrams(-10)
+        viewModel.updateCustomFatGrams(100)
+        viewModel.updateCustomCarbGrams(100)
+
+        val state = viewModel.formState.value
+        assertEquals(-10, state.customProteinGrams)
+        assertNotNull(state.customModeError)
+        assertFalse(state.isValid)
+    }
+
+    @Test
+    fun settingsViewModel_targetWeightChange_outOfRange_showsError() {
+        val viewModel = SettingsViewModel()
+        viewModel.updateWeight("80")
+        viewModel.updateHeight("180")
+        viewModel.updateAge("30")
+        viewModel.updateTargetWeightChange("-10")
+
+        val state = viewModel.formState.value
+        assertEquals("-10", state.targetWeightChangeKg)
+        assertNotNull(state.targetWeightChangeError)
+        assertFalse(state.isValid)
     }
 }


### PR DESCRIPTION
## Summary
- **Remove all input sanitization patterns** that silently modified user values (`coerceIn`, `coerceAtLeast`, character filtering, `?: 0` fallbacks)
- **Replace with proper validation** - invalid input is preserved exactly as typed, with clear error messages shown
- **Add per-field validation errors** to `SettingsFormState` for weight, height, age, target weight change, and custom distribution percentages

## What Changed

### `SettingsViewModel.kt`
- Removed `coerceIn(0, 100)` from custom percentage inputs (e.g. 200 stays 200, shows error)
- Removed `coerceIn(0, 1000)` from manual macro gram inputs (e.g. 2000 stays 2000, shows error)
- Removed `.filter { ... }` character stripping from weight/height/age/target inputs (e.g. "80kg" stays "80kg", shows error)
- Removed all `?: 0` / `?: 0f` fallbacks in `recalculate()` and `performSave()`
- Added `weightError`, `heightError`, `ageError`, `targetWeightChangeError` fields to form state
- `performSave()` aborts if form is invalid instead of persisting corrupted zeros

### `SettingsFormState`
- Changed `customProteinPercent/Fat/Carb` from `Int` to `String`
- Changed `customProteinGrams/Fat/CarbGrams` from `Int` to `String`
- Added validation error fields per input

### `SettingsScreen.kt`
- Removed `?: 0` from all `onValueChange` handlers
- Fields display specific validation errors in `supportingText`
- Fields show `isError` state based on ViewModel errors

### `SettingsViewModelTest.kt`
- Updated tests to match new behavior (input preserved, not filtered)
- Added 7 new validation tests covering out-of-range values, invalid strings, negative numbers, etc.

## Behavior Change
| Before | After |
|--------|-------|
| User types 800g protein → silently clamped to 1000 | 800g preserved, validated against reasonable bounds |
| User types "abc" → becomes 0 | "abc" preserved, error shown |
| User types "80kg" → becomes "80" | "80kg" preserved, error shown |
| Empty field → 0 saved to DB | Form invalid, save aborted |
| Calories below minimum → silently raised | Minimum still enforced but as a floor, not input modification |