### PR TITLE
Fix settings not saving partial data when form is invalid

### DIFF
--- a/app/src/main/java/pro/trousev/mealcontrol/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/viewmodel/SettingsViewModel.kt
@@ -433,7 +433,6 @@ class SettingsViewModel : ViewModel() {
                     ageError = null,
                     targetWeightChangeError = null,
                 )
-            saveTrigger.trySend(Unit)
         } else {
             _formState.value =
                 state.copy(
@@ -446,27 +445,21 @@ class SettingsViewModel : ViewModel() {
                     targetWeightChangeError = targetWeightChangeError,
                 )
         }
+        saveTrigger.trySend(Unit)
     }
 
     private suspend fun performSave() {
         val state = _formState.value
-        if (!state.isValid) return
-
         val isManualMode = state.workingMode == WorkingMode.MANUAL
-
-        val weight = state.weightKg.toFloatOrNull() ?: return
-        val height = state.heightCm.toFloatOrNull() ?: return
-        val age = state.age.toIntOrNull() ?: return
-        val targetChange = state.targetWeightChangeKg.toFloatOrNull() ?: return
 
         val settings =
             UserSettingsEntity(
                 id = 1,
-                weightKg = weight,
-                heightCm = height,
-                age = age,
+                weightKg = state.weightKg.toFloatOrNull() ?: 0f,
+                heightCm = state.heightCm.toFloatOrNull() ?: 0f,
+                age = state.age.toIntOrNull() ?: 0,
                 gender = state.gender.name,
-                targetWeightChangeKg = targetChange,
+                targetWeightChangeKg = state.targetWeightChangeKg.toFloatOrNull() ?: 0f,
                 activityLevel = state.activityLevel.ordinal + 1,
                 calorieDistribution = state.calorieDistribution.name,
                 customProteinPercent = state.customProteinPercent,


### PR DESCRIPTION
## Summary
- Fix settings (like weight in "Body Measurements") not being saved when user enters partial data
- Previously, save only triggered when all form fields were valid (weight + height + age), causing data loss on certain devices
- Now `saveTrigger.trySend(Unit)` fires regardless of form validity in `recalculate()`

## Problem
Users entering just their weight and exiting the app would lose that data because the form was considered "invalid" (missing height/age).

## Fix
Moved `saveTrigger.trySend(Unit)` outside the `if (isValid)` block in `recalculate()` so partial settings are always persisted to Room database.

## Testing
- [x] Enter weight → wait 300ms → exit app → reopen → weight persists
- [x] Lint passes

Fixes issue with settings not restoring on specific Android device.