### PR TITLE
handle-corrupted-prefs

### DIFF
--- a/app/src/main/java/pro/trousev/mealcontrol/util/ApiKeyManager.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/util/ApiKeyManager.kt
@@ -5,6 +5,8 @@ import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import java.io.File
+import javax.crypto.AEADBadTagException
 
 interface SecureStorage {
     fun storeApiKey(apiKey: String)
@@ -29,14 +31,28 @@ class ApiKeyManager(
                     .build(),
             ).build()
 
-    private val sharedPreferences =
-        EncryptedSharedPreferences.create(
-            context,
-            PREFS_NAME,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-        )
+    private val sharedPreferences = createEncryptedSharedPreferences()
+
+    private fun createEncryptedSharedPreferences() =
+        try {
+            EncryptedSharedPreferences.create(
+                context,
+                PREFS_NAME,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+            )
+        } catch (e: AEADBadTagException) {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit().clear().apply()
+            File(context.filesDir.parent, "shared_prefs/$PREFS_NAME.xml").delete()
+            EncryptedSharedPreferences.create(
+                context,
+                PREFS_NAME,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+            )
+        }
 
     override fun storeApiKey(apiKey: String) {
         sharedPreferences.edit().putString(KEY_API_KEY, apiKey).apply()

--- a/app/src/main/java/pro/trousev/mealcontrol/util/ApiKeyManager.kt
+++ b/app/src/main/java/pro/trousev/mealcontrol/util/ApiKeyManager.kt
@@ -43,7 +43,11 @@ class ApiKeyManager(
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
             )
         } catch (e: AEADBadTagException) {
-            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit().clear().apply()
+            context
+                .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .clear()
+                .apply()
             File(context.filesDir.parent, "shared_prefs/$PREFS_NAME.xml").delete()
             EncryptedSharedPreferences.create(
                 context,


### PR DESCRIPTION
Improved error handling for encrypted shared preferences in the ApiKeyManager to recover from data corruption.

The changes introduce a try-catch block around the creation of EncryptedSharedPreferences, specifically handling AEADBadTagException by clearing corrupted data and recreating the storage. This prevents app crashes or failures when encrypted API key data becomes invalid, ensuring reliable secure storage. The motivation is to enhance app robustness and user experience by gracefully recovering from potential encryption-related issues, which could arise from system updates or device-specific problems, thereby maintaining the functionality of API key persistence without requiring manual intervention.